### PR TITLE
[MB-1676] proper serialization

### DIFF
--- a/Assets/UrbanAirship/Platforms/UAirship.cs
+++ b/Assets/UrbanAirship/Platforms/UAirship.cs
@@ -6,8 +6,30 @@ using UnityEngine;
 using System.Collections;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace UrbanAirship {
+
+	[System.Serializable]
+	class JsonArray<T>
+	{
+		public T[] values = null;
+
+		public static JsonArray<T> FromJson (T jsonString)
+		{
+			string wrappedArray = string.Format ("{{ \"{0}\": {1}}}", "values", jsonString);
+			return JsonUtility.FromJson<JsonArray<T>> (wrappedArray);
+		}
+
+		public IEnumerable<T> AsEnumerable () 
+		{
+			if (this.values == null) {
+				return new T[0].AsEnumerable ();
+			} else {
+				return this.values.AsEnumerable ();
+			}
+		}
+	}
 
 	public class UAirship
 	{
@@ -29,10 +51,11 @@ namespace UrbanAirship {
 			}
 		}
 
-		// TODO: Decode the json array of tags
-		public static string Tags {
+		public static IEnumerable<string> Tags {
 			get {
-				return plugin.Tags;
+				string tagsAsJson = plugin.Tags;
+				JsonArray<string> jsonArray = JsonArray<string>.FromJson (tagsAsJson);
+				return jsonArray.AsEnumerable ();
 			}
 		}
 


### PR DESCRIPTION
Unity does have a JSON library, albeit a limited one. It's not possible to do arbitrary JSON object manipulation – you have to create classes or structs marked serializable and the appropriate fields will be filled out (or not).

Some fussy details:

* If the JSON string doesn't exactly match the model JsonUtility is working with, missing fields will just be left empty/null on the resulting model object. We need to be careful to make sure fields are non-null when deserializing
* JsonUtility does appear to throw exceptions if the input string is either malformed or null. Since this would be our (as opposed to the customer's) mistake, and since these script exceptions don't appear to crash the game, it's probably in our best interest to let them be thrown so that customers are more likely to recognize the problem and alert us if we did something dumb

I'm open to suggestions or opposing views on that last point, just trying to make this as robust as necessary without being heavy handed or obfuscating potential problems down the road.