### PR TITLE
[MB-1671] full push payload support

### DIFF
--- a/Assets/UrbanAirship/Platforms/CustomEvent.cs
+++ b/Assets/UrbanAirship/Platforms/CustomEvent.cs
@@ -1,0 +1,115 @@
+﻿/*
+ Copyright 2016 Urban Airship and Contributors
+*/
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using System.Linq;
+
+namespace UrbanAirship
+{
+	[System.Serializable]
+	public class CustomEvent
+	{
+		[SerializeField]
+		private string eventName;
+		[SerializeField]
+		private string eventValue;
+		[SerializeField]
+		private string transactionId;
+		[SerializeField]
+		private string interactionType;
+		[SerializeField]
+		private string interactionId;
+		[SerializeField]
+		private Property[] properties;
+
+		private List<Property> propertyList;
+
+
+		public CustomEvent()
+		{
+			this.propertyList = new List<Property> ();
+		}
+
+		public string EventName {
+			get { return eventName; }
+			set { eventName = value; }
+		}
+		public decimal EventValue {
+			get { return Decimal.Parse (eventValue); }
+			set { eventValue = value.ToString (); }
+		}
+
+		public string TransactionId {
+			get { return transactionId; }
+			set { transactionId = value; }
+		}
+
+		public string InteractionType {
+			get { return interactionType; }
+			set { interactionType = value; }
+		}
+
+		public string InteractionId {
+			get { return interactionId; }
+			set { interactionId = value; }
+		}
+
+		public void AddProperty(string name, string value)
+		{
+			this.propertyList.Add (new Property ("s", name, value));
+		}
+
+		public void AddProperty(string name, double value)
+		{
+			this.propertyList.Add (new Property ("d", name, value));
+		}
+
+		public void AddProperty(string name, bool value)
+		{
+			this.propertyList.Add (new Property ("b", name, value));
+		}
+
+		public void AddProperty(string name, ICollection<string> value)
+		{
+			this.propertyList.Add (new Property ("sa", name, value));
+		}
+
+		public string ToJson ()
+		{
+			this.properties = this.propertyList.ToArray ();
+			return JsonUtility.ToJson (this);
+		}
+
+		[Serializable]
+		class Property
+		{
+			public string type;
+			public string name;
+			public string stringValue;
+			public double doubleValue;
+			public bool boolValue;
+			public string[] stringArrayValue;
+
+			public Property(string type, string name, System.Object value)
+			{
+				this.type = type;
+				this.name = name;
+
+				if (type == "s") {
+					this.stringValue = (string) value;
+				} else if (type == "d") {
+					this.doubleValue = (double) value;
+				} else if (type == "b") {
+					this.boolValue = (bool) value;
+				} else if (type == "sa") {
+					ICollection<string> collection = (ICollection<string>) value;
+					this.stringArrayValue = collection.ToArray ();
+				}
+			}
+		}
+	}
+}
+

--- a/Assets/UrbanAirship/Platforms/IUAirshipPlugin.cs
+++ b/Assets/UrbanAirship/Platforms/IUAirshipPlugin.cs
@@ -10,7 +10,6 @@ namespace UrbanAirship {
 
 	interface IUAirshipPlugin
 	{
-
 		bool PushEnabled {
 			get;
 			set;

--- a/Assets/UrbanAirship/Platforms/JsonArray.cs
+++ b/Assets/UrbanAirship/Platforms/JsonArray.cs
@@ -1,0 +1,38 @@
+﻿/*
+ Copyright 2016 Urban Airship and Contributors
+ */
+
+using System;
+using UnityEngine;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UrbanAirship
+{
+	[System.Serializable]
+	class JsonArray<T>
+	{
+		public T[] values = null;
+
+		public static JsonArray<T> FromJson (string jsonString)
+		{
+			string wrappedArray = string.Format ("{{ \"{0}\": {1}}}", "values", jsonString);
+			return JsonUtility.FromJson<JsonArray<T>> (wrappedArray);
+		}
+
+		public IEnumerable<T> AsEnumerable () 
+		{
+			if (this.values == null) {
+				return new T[0].AsEnumerable ();
+			} else {
+				return this.values.AsEnumerable ();
+			}
+		}
+
+		public string ToJson ()
+		{
+			return JsonUtility.ToJson (this);
+		}
+	}
+}
+

--- a/Assets/UrbanAirship/Platforms/PushMessage.cs
+++ b/Assets/UrbanAirship/Platforms/PushMessage.cs
@@ -1,0 +1,65 @@
+﻿/*
+ Copyright 2016 Urban Airship and Contributors
+*/
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UrbanAirship
+{
+	[Serializable]
+	public class PushMessage
+	{
+		[SerializeField]
+		private string alert;
+		[SerializeField]
+		private string identifier;
+		[SerializeField]
+		private Extra[] extras;
+
+		private Dictionary<string, string> extrasDictionary;
+
+		[Serializable]
+		class Extra
+		{
+			public string key;
+			public string value;
+		}
+
+		public string Alert {
+			get { return this.alert; }
+		}
+
+		public string Identifier {
+			get { return this.identifier; }
+		}
+
+		public Dictionary<string, string> Extras {
+			get {
+				if (extras == null) {
+					return null;
+				}
+
+				if (this.extrasDictionary == null) {
+					this.extrasDictionary = new Dictionary<string, string> ();
+					foreach (Extra extra in extras) {
+						this.extrasDictionary.Add (extra.key, extra.value);
+					}
+				}
+
+				return this.extrasDictionary;
+			}
+		}
+
+		public static PushMessage FromJson (string jsonString)
+		{
+			PushMessage pushMessage = JsonUtility.FromJson<PushMessage> (jsonString);
+			if (pushMessage.Alert == null && pushMessage.Identifier == null && pushMessage.Extras == null) {
+				return null;
+			}
+			return pushMessage;
+		}
+	}
+}
+

--- a/Assets/UrbanAirship/Platforms/UAirship.cs
+++ b/Assets/UrbanAirship/Platforms/UAirship.cs
@@ -10,189 +10,6 @@ using System.Linq;
 
 namespace UrbanAirship {
 
-	[System.Serializable]
-	class JsonArray<T>
-	{
-		public T[] values = null;
-
-		public static JsonArray<T> FromJson (string jsonString)
-		{
-			string wrappedArray = string.Format ("{{ \"{0}\": {1}}}", "values", jsonString);
-			return JsonUtility.FromJson<JsonArray<T>> (wrappedArray);
-		}
-
-		public IEnumerable<T> AsEnumerable () 
-		{
-			if (this.values == null) {
-				return new T[0].AsEnumerable ();
-			} else {
-				return this.values.AsEnumerable ();
-			}
-		}
-
-		public string ToJson ()
-		{
-			return JsonUtility.ToJson (this);
-		}
-	}
-
-	[System.Serializable]
-	public class CustomEvent
-	{
-		[SerializeField]
-		private string eventName;
-		[SerializeField]
-		private string eventValue;
-		[SerializeField]
-		private string transactionId;
-		[SerializeField]
-		private string interactionType;
-		[SerializeField]
-		private string interactionId;
-		[SerializeField]
-		private Property[] properties;
-
-		private List<Property> propertyList;
-
-
-		public CustomEvent()
-		{
-			this.propertyList = new List<Property> ();
-		}
-
-		public string EventName {
-			get { return eventName; }
-			set { eventName = value; }
-		}
-		public decimal EventValue {
-			get { return Decimal.Parse (eventValue); }
-			set { eventValue = value.ToString (); }
-		}
-
-		public string TransactionId {
-			get { return transactionId; }
-			set { transactionId = value; }
-		}
-
-		public string InteractionType {
-			get { return interactionType; }
-			set { interactionType = value; }
-		}
-
-		public string InteractionId {
-			get { return interactionId; }
-			set { interactionId = value; }
-		}
-
-		public void AddProperty(string name, string value)
-		{
-			this.propertyList.Add (new Property ("s", name, value));
-		}
-
-		public void AddProperty(string name, double value)
-		{
-			this.propertyList.Add (new Property ("d", name, value));
-		}
-
-		public void AddProperty(string name, bool value)
-		{
-			this.propertyList.Add (new Property ("b", name, value));
-		}
-
-		public void AddProperty(string name, ICollection<string> value)
-		{
-			this.propertyList.Add (new Property ("sa", name, value));
-		}
-
-		public string ToJson ()
-		{
-			this.properties = this.propertyList.ToArray ();
-			return JsonUtility.ToJson (this);
-		}
-
-		[Serializable]
-		class Property
-		{
-			public string type;
-			public string name;
-			public string stringValue;
-			public double doubleValue;
-			public bool boolValue;
-			public string[] stringArrayValue;
-
-			public Property(string type, string name, System.Object value)
-			{
-				this.type = type;
-				this.name = name;
-
-				if (type == "s") {
-					this.stringValue = (string) value;
-				} else if (type == "d") {
-					this.doubleValue = (double) value;
-				} else if (type == "b") {
-					this.boolValue = (bool) value;
-				} else if (type == "sa") {
-					ICollection<string> collection = (ICollection<string>) value;
-					this.stringArrayValue = collection.ToArray ();
-				}
-			}
-		}
-	}
-
-	[Serializable]
-	public class PushMessage
-	{
-		[SerializeField]
-		private string alert;
-		[SerializeField]
-		private string identifier;
-		[SerializeField]
-		private Extra[] extras;
-
-		private Dictionary<string, string> extrasDictionary;
-
-		[Serializable]
-		class Extra
-		{
-			public string key;
-			public string value;
-		}
-
-		public string Alert {
-			get { return this.alert; }
-		}
-
-		public string Identifier {
-			get { return this.identifier; }
-		}
-
-		public Dictionary<string, string> Extras {
-			get {
-				if (extras == null) {
-					return null;
-				}
-
-				if (this.extrasDictionary == null) {
-					this.extrasDictionary = new Dictionary<string, string> ();
-					foreach (Extra extra in extras) {
-						this.extrasDictionary.Add (extra.key, extra.value);
-					}
-				}
-
-				return this.extrasDictionary;
-			}
-		}
-
-		public static PushMessage FromJson (string jsonString)
-		{
-			PushMessage pushMessage = JsonUtility.FromJson<PushMessage> (jsonString);
-			if (pushMessage.Alert == null && pushMessage.Identifier == null && pushMessage.Extras == null) {
-				return null;
-			}
-			return pushMessage;
-		}
-	}
-
 	public class UAirship
 	{
 
@@ -290,6 +107,10 @@ namespace UrbanAirship {
 		{
 			if (plugin != null) {
 				string jsonPushMessage = plugin.GetIncomingPush (clear);
+				if (String.IsNullOrEmpty(jsonPushMessage)) {
+					return null;
+				}
+
 				PushMessage pushMessage = PushMessage.FromJson (jsonPushMessage);
 				return pushMessage;
 			}
@@ -310,7 +131,7 @@ namespace UrbanAirship {
 			}
 		}
 
-		public static void addCustomEvent (CustomEvent customEvent)
+		public static void AddCustomEvent (CustomEvent customEvent)
 		{
 			if (plugin != null) {
 				plugin.AddCustomEvent (customEvent.ToJson ());

--- a/Assets/UrbanAirship/Platforms/UAirship.cs
+++ b/Assets/UrbanAirship/Platforms/UAirship.cs
@@ -15,8 +15,7 @@ namespace UrbanAirship {
 	{
 		public T[] values = null;
 
-
-		public static JsonArray<T> FromJson (T jsonString)
+		public static JsonArray<T> FromJson (string jsonString)
 		{
 			string wrappedArray = string.Format ("{{ \"{0}\": {1}}}", "values", jsonString);
 			return JsonUtility.FromJson<JsonArray<T>> (wrappedArray);
@@ -35,7 +34,6 @@ namespace UrbanAirship {
 		{
 			return JsonUtility.ToJson (this);
 		}
-
 	}
 
 	[System.Serializable]
@@ -141,6 +139,60 @@ namespace UrbanAirship {
 		}
 	}
 
+	[Serializable]
+	public class PushMessage
+	{
+		[SerializeField]
+		private string alert;
+		[SerializeField]
+		private string identifier;
+		[SerializeField]
+		private Extra[] extras;
+
+		private Dictionary<string, string> extrasDictionary;
+
+		[Serializable]
+		class Extra
+		{
+			public string key;
+			public string value;
+		}
+
+		public string Alert {
+			get { return this.alert; }
+		}
+
+		public string Identifier {
+			get { return this.identifier; }
+		}
+
+		public Dictionary<string, string> Extras {
+			get {
+				if (extras == null) {
+					return null;
+				}
+
+				if (this.extrasDictionary == null) {
+					this.extrasDictionary = new Dictionary<string, string> ();
+					foreach (Extra extra in extras) {
+						this.extrasDictionary.Add (extra.key, extra.value);
+					}
+				}
+
+				return this.extrasDictionary;
+			}
+		}
+
+		public static PushMessage FromJson (string jsonString)
+		{
+			PushMessage pushMessage = JsonUtility.FromJson<PushMessage> (jsonString);
+			if (pushMessage.Alert == null && pushMessage.Identifier == null && pushMessage.Extras == null) {
+				return null;
+			}
+			return pushMessage;
+		}
+	}
+
 	public class UAirship
 	{
 
@@ -234,10 +286,12 @@ namespace UrbanAirship {
 			return null;
 		}
 
-		public static string GetIncomingPush (bool clear = true)
+		public static PushMessage GetIncomingPush (bool clear = true)
 		{
 			if (plugin != null) {
-				return plugin.GetIncomingPush (clear);
+				string jsonPushMessage = plugin.GetIncomingPush (clear);
+				PushMessage pushMessage = PushMessage.FromJson (jsonPushMessage);
+				return pushMessage;
 			}
 			return null;
 		}

--- a/android-plugin-lib/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
+++ b/android-plugin-lib/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
@@ -20,8 +20,10 @@ import com.urbanairship.util.UAStringUtil;
 import org.json.JSONArray;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class UnityPlugin {
@@ -307,12 +309,32 @@ public class UnityPlugin {
         }
     }
 
-    private String getPushPayload(PushMessage pushMessage) {
-        if (pushMessage == null) {
-            return "";
+    private String getPushPayload(PushMessage message) {
+        if (message == null) {
+            return null;
         }
 
-        return pushMessage.getAlert();
+        Map<String, Object> payloadMap = new HashMap<>();
+
+        List<Map<String, String>> extras = new ArrayList<>();
+
+        for (String key : message.getPushBundle().keySet()) {
+            String value = message.getPushBundle().getString(key);
+            if (value == null) {
+                continue;
+            }
+
+            Map<String, String> extra = new HashMap<>();
+            extra.put("key", key);
+            extra.put("value", value);
+            extras.add(extra);
+        }
+
+        payloadMap.put("alert", message.getAlert());
+        payloadMap.put("identifier", message.getSendId());
+        payloadMap.put("extras", extras);
+
+        return JsonValue.wrapOpt(payloadMap).toString();
     }
 
     void setDeepLink(String deepLink) {


### PR DESCRIPTION
"Full" push payload support. The only caveat here is that, once again largely due to the decrepitude of JsonUtility, we're not fully deserializing extras. This is essentially the same situation as on Android, where extras are <string, string> and arbitrarily encoded non-string values are still presented as strings. That should be enough, though.

todo: Android native plugin implementation