### PR TITLE
[MB-1701] Theme the message center

### DIFF
--- a/android-plugin-lib/build.gradle
+++ b/android-plugin-lib/build.gradle
@@ -42,6 +42,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
     compile 'com.urbanairship:urbanairship-sdk:+@aar'
+    compile 'com.android.support:support-v4:23.1.1'
+    compile 'com.android.support:support-annotations:23.1.1'
 }
 
 task copyUnityClassesJar() {

--- a/android-plugin-lib/src/main/AndroidManifest.xml
+++ b/android-plugin-lib/src/main/AndroidManifest.xml
@@ -1,23 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.urbanairship.unityplugin">
+    package="com.urbanairship.unityplugin"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
 
         <!-- Urban Airship Plugin -->
-        <receiver android:name="com.urbanairship.unityplugin.IntentReceiver" android:exported="false">
+        <receiver
+            android:name="com.urbanairship.unityplugin.IntentReceiver"
+            android:exported="false">
             <intent-filter>
-                <action android:name="com.urbanairship.push.CHANNEL_UPDATED" />
-                <action android:name="com.urbanairship.push.OPENED" />
-                <action android:name="com.urbanairship.push.DISMISSED" />
-                <action android:name="com.urbanairship.push.RECEIVED" />
-                <category android:name="${applicationId}" />
+                <action android:name="com.urbanairship.push.CHANNEL_UPDATED"/>
+                <action android:name="com.urbanairship.push.OPENED"/>
+                <action android:name="com.urbanairship.push.DISMISSED"/>
+                <action android:name="com.urbanairship.push.RECEIVED"/>
+
+                <category android:name="${applicationId}"/>
             </intent-filter>
         </receiver>
 
-        <meta-data android:name="com.urbanairship.autopilot" android:value="com.urbanairship.unityplugin.UnityAutopilot" />
+        <meta-data
+            android:name="com.urbanairship.autopilot"
+            android:value="com.urbanairship.unityplugin.UnityAutopilot"/>
 
+        <activity android:name=".CustomMessageCenterActivity"
+                  android:theme="@style/MessageCenterTheme"
+                  android:label="@string/ua_message_center_title">
+
+
+            <intent-filter>
+                <action android:name="com.urbanairship.VIEW_RICH_PUSH_INBOX" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+
+        </activity>
+
+        <activity android:name=".CustomMessageActivity"
+                  android:theme="@style/MessageCenterTheme">
+
+            <intent-filter>
+                <action android:name="com.urbanairship.VIEW_RICH_PUSH_MESSAGE" />
+                <data android:scheme="message"/>
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+
+        </activity>
     </application>
-   
+
 </manifest>

--- a/android-plugin-lib/src/main/java/com/urbanairship/unityplugin/CustomMessageActivity.java
+++ b/android-plugin-lib/src/main/java/com/urbanairship/unityplugin/CustomMessageActivity.java
@@ -1,0 +1,11 @@
+/*
+ Copyright 2016 Urban Airship and Contributors
+*/
+package com.urbanairship.unityplugin;
+
+import com.urbanairship.messagecenter.MessageActivity;
+
+// Copy of the MessageActivity so we can set a different theme
+public class CustomMessageActivity extends MessageActivity {
+
+}

--- a/android-plugin-lib/src/main/java/com/urbanairship/unityplugin/CustomMessageCenterActivity.java
+++ b/android-plugin-lib/src/main/java/com/urbanairship/unityplugin/CustomMessageCenterActivity.java
@@ -1,0 +1,11 @@
+/*
+ Copyright 2016 Urban Airship and Contributors
+*/
+
+package com.urbanairship.unityplugin;
+
+import com.urbanairship.messagecenter.MessageCenterActivity;
+
+// Copy of the MessageCenterActivity so we can set a different theme
+public class CustomMessageCenterActivity extends MessageCenterActivity {
+}

--- a/android-plugin-lib/src/main/res/values-v14/style.xml
+++ b/android-plugin-lib/src/main/res/values-v14/style.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+
+    <!-- Applied to the MessageCenter activities -->
+    <style name="MessageCenterTheme" parent="@android:style/Theme.DeviceDefault.Light.DarkActionBar">
+        <item name="messageCenterStyle">@style/MessageCenterTheme.MessageCenter</item>
+    </style>
+
+    <!-- Apply any overrides http://docs.urbanairship.com/platform/android.html#styling-the-message-center -->
+    <style name="MessageCenterTheme.MessageCenter" parent="MessageCenter">
+
+    </style>
+
+</resources>


### PR DESCRIPTION
The default unity theme is full screen no action bar, this sets a default action bar theme to the message center activities. I am unable to override the manifest entries so I had to create new activities that I could add to the manifest. 