### PR TITLE
[MB-1982] Add support for associated identifiers.

### DIFF
--- a/Assets/Plugins/iOS/UAUnityPlugin.h
+++ b/Assets/Plugins/iOS/UAUnityPlugin.h
@@ -48,6 +48,10 @@ void UAUnityPlugin_setBackgroundLocationAllowed(bool allowed);
 void UAUnityPlugin_addCustomEvent(const char *customEvent);
 
 #pragma mark -
+#pragma mark Associated Identifier
+void UAUnityPlugin_associateIdentifier(const char *key, const char *identifier);
+
+#pragma mark -
 #pragma mark Named User
 void UAUnityPlugin_setNamedUserID(const char *namedUserID);
 const char* UAUnityPlugin_getNamedUserID();

--- a/Assets/Plugins/iOS/UAUnityPlugin.m
+++ b/Assets/Plugins/iOS/UAUnityPlugin.m
@@ -17,6 +17,7 @@
 #import "UACustomEvent.h"
 #import "UAUtils.h"
 #import "UADefaultMessageCenter.h"
+#import "UAAssociatedIdentifiers.h"
 
 static UAUnityPlugin *shared_;
 static dispatch_once_t onceToken_;
@@ -229,6 +230,27 @@ void UAUnityPlugin_addCustomEvent(const char *customEvent) {
     }
 
     [[UAirship shared].analytics addEvent:ce];
+}
+
+void UAUnityPlugin_associateIdentifier(const char *key, const char *identifier) {
+    if (!key) {
+        UA_LDEBUG(@"UnityPlugin associateIdentifier failed, key cannot be nil");
+        return;
+    }
+
+    NSString *keyString = [UAUnityPlugin stringOrNil:[NSString stringWithUTF8String:key]];
+    NSString *identifierString = nil;
+
+    if (!identifier) {
+        UA_LDEBUG(@"UnityPlugin associateIdentifier removed identifier for key: %@", keyString);
+    } else {
+        identifierString = [UAUnityPlugin stringOrNil:[NSString stringWithUTF8String:identifier]];
+        UA_LDEBUG(@"UnityPlugin associateIdentifier with identifier: %@ for key: %@", identifierString, keyString);
+    }
+
+    UAAssociatedIdentifiers *identifiers = [[UAirship shared].analytics currentAssociatedDeviceIdentifiers];
+    [identifiers setIdentifier:identifierString forKey:keyString];
+    [[UAirship shared].analytics associateDeviceIdentifiers:identifiers];
 }
 
 void UAUnityPlugin_setNamedUserID(const char *namedUserID) {

--- a/Assets/UrbanAirship/Platforms/Android/UAirshipPluginAndroid.cs
+++ b/Assets/UrbanAirship/Platforms/Android/UAirshipPluginAndroid.cs
@@ -116,6 +116,11 @@ namespace UrbanAirship {
 			Call ("addCustomEvent", customEvent);
 		}
 
+		public void AssociateIdentifier (string key, string identifier)
+		{
+			Call ("associateIdentifier", key, identifier);
+		}
+
 		public void DisplayMessageCenter ()
 		{
 			Call ("displayMessageCenter");

--- a/Assets/UrbanAirship/Platforms/IUAirshipPlugin.cs
+++ b/Assets/UrbanAirship/Platforms/IUAirshipPlugin.cs
@@ -57,6 +57,8 @@ namespace UrbanAirship {
 
 		void AddCustomEvent (string customEvent);
 
+		void AssociateIdentifier (string key, string identifier);
+
 		void DisplayMessageCenter ();
 
 		void EditNamedUserTagGroups (string payload);

--- a/Assets/UrbanAirship/Platforms/StubbedPlugin.cs
+++ b/Assets/UrbanAirship/Platforms/StubbedPlugin.cs
@@ -21,6 +21,7 @@ namespace UrbanAirship
 		public void AddTag (string tag) {}
 		public void RemoveTag (string tag) {}
 		public void AddCustomEvent (string customEvent) {}
+		public void AssociateIdentifier (string key, string identifier) {}
 		public void DisplayMessageCenter () {}
 		public void EditNamedUserTagGroups (string payload) {}
 		public void EditChannelTagGroups (string payload) {}

--- a/Assets/UrbanAirship/Platforms/UAirship.cs
+++ b/Assets/UrbanAirship/Platforms/UAirship.cs
@@ -210,6 +210,18 @@ namespace UrbanAirship {
 		}
 
 		/// <summary>
+		/// Associate a custom identifier.
+		/// Previous identifiers will be replaced by the new identifiers each time AssociateIdentifier is called.
+		/// It is a set operation.
+		/// </summary>
+		/// <param name="key">The custom key for the identifier.</param>
+		/// <param name="identifier">The value of the identifier, or `null` to remove the identifier.</param>
+		public void AssociateIdentifier (string key, string identifier)
+		{
+			plugin.AssociateIdentifier (key, identifier);
+		}
+
+		/// <summary>
 		/// Displays the message center.
 		/// </summary>
 		public void DisplayMessageCenter ()

--- a/Assets/UrbanAirship/Platforms/iOS/UAirshipPluginIOS.cs
+++ b/Assets/UrbanAirship/Platforms/iOS/UAirshipPluginIOS.cs
@@ -63,6 +63,9 @@ namespace UrbanAirship {
 		private static extern void UAUnityPlugin_addCustomEvent (string customEvent);
 
 		[DllImport ("__Internal")]
+		private static extern void UAUnityPlugin_associateIdentifier (string key, string identifier);
+
+		[DllImport ("__Internal")]
 		private static extern string UAUnityPlugin_getNamedUserID ();
 
 		[DllImport ("__Internal")]
@@ -164,6 +167,11 @@ namespace UrbanAirship {
 		public void AddCustomEvent (string customEvent)
 		{
 			UAUnityPlugin_addCustomEvent (customEvent);
+		}
+
+		public void AssociateIdentifier (string key, string identifier)
+		{
+			UAUnityPlugin_associateIdentifier (key, identifier);
 		}
 
 		public void DisplayMessageCenter ()

--- a/android-plugin-lib/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
+++ b/android-plugin-lib/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
@@ -222,6 +222,21 @@ public class UnityPlugin {
         UAirship.shared().getAnalytics().addEvent(eventBuilder.create());
     }
 
+    public void associateIdentifier(String key, String identifier) {
+        if (key == null) {
+            Logger.debug("UnityPlugin associateIdentifier failed, key cannot be null");
+            return;
+        }
+
+        if (identifier == null) {
+            Logger.debug("UnityPlugin associateIdentifier removed identifier for key: " + key);
+            UAirship.shared().getAnalytics().editAssociatedIdentifiers().removeIdentifier(key).apply();
+        } else {
+            Logger.debug("UnityPlugin associateIdentifier with identifier: " + identifier + " for key: " + key);
+            UAirship.shared().getAnalytics().editAssociatedIdentifiers().addIdentifier(key, identifier).apply();
+        }
+    }
+
     public String getNamedUserId() {
         Logger.debug("UnityPlugin getNamedUserId");
         return UAirship.shared().getNamedUser().getId();


### PR DESCRIPTION
Added `AssociateIdentifier` method to set custom identifiers.

Testing:

        UAirship.Shared.AssociateIdentifier ("ice", "cream");
        UAirship.Shared.AssociateIdentifier ("friend", "ship");
        UAirship.Shared.AssociateIdentifier (null, "ship"); // invalid null key
        UAirship.Shared.AssociateIdentifier ("friend", null); // removes identifier for key 'friend'

// android
UALib: UnityPlugin associateIdentifier with identifier: cream for key: ice
UALib: PreferenceDataStore - Saving preference: com.urbanairship.analytics.ASSOCIATED_IDENTIFIERS value: {"ice":"cream"}
UALib: Analytics - Adding event: associate_identifiers
UALib: UnityPlugin associateIdentifier with identifier: ship for key: friend
UALib: PreferenceDataStore - Saving preference: com.urbanairship.analytics.ASSOCIATED_IDENTIFIERS value: {"ice":"cream","friend":"ship"}
UALib: Analytics - Adding event: associate_identifiers
UALib: UnityPlugin associateIdentifier failed, key cannot be null
UALib: UnityPlugin associateIdentifier removed identifier for key: friend
UALib: Analytics - Adding event: associate_identifiers
UALib: PreferenceDataStore - Saving preference: com.urbanairship.analytics.ASSOCIATED_IDENTIFIERS value: {"ice":"cream"}

// iOS
void UAUnityPlugin_associateIdentifier(const char *, const char *) [Line 248] UnityPlugin associateIdentifier with identifier: cream for key: ice
[UAAnalytics addEvent:] [Line 237] Adding associate_identifiers event C84755B3-75F3-4C3F-9AC1-9EAB63B83F1A.
[UAAnalytics addEvent:] [Line 253] Added: UAEvent ID: C84755B3-75F3-4C3F-9AC1-9EAB63B83F1A type: associate_identifiers time: 1475515775.775765 data: {
    ice = cream;
}.
void UAUnityPlugin_associateIdentifier(const char *, const char *) [Line 248] UnityPlugin associateIdentifier with identifier: ship for key: friend
[UAAnalytics addEvent:] [Line 237] Adding associate_identifiers event F96B4935-9F0E-4213-B664-FFC95B021DF3.
[UAAnalytics addEvent:] [Line 253] Added: UAEvent ID: F96B4935-9F0E-4213-B664-FFC95B021DF3 type: associate_identifiers time: 1475515775.776524 data: {
    friend = ship;
    ice = cream;
}.
void UAUnityPlugin_associateIdentifier(const char *, const char *) [Line 237] UnityPlugin associateIdentifier failed, key cannot be nil
void UAUnityPlugin_associateIdentifier(const char *, const char *) [Line 245] UnityPlugin associateIdentifier removed identifier for key: friend
[UAAnalytics addEvent:] [Line 237] Adding associate_identifiers event 846DC994-D1E2-439A-939A-EF754BA399D9.
[UAAnalytics addEvent:] [Line 253] Added: UAEvent ID: 846DC994-D1E2-439A-939A-EF754BA399D9 type: associate_identifiers time: 1475515775.780846 data: {
    ice = cream;
}.