### PR TITLE
[MB-1975] Added iOS foreground presentation support.

### DIFF
--- a/Assets/Plugins/iOS/UAUnityPlugin.m
+++ b/Assets/Plugins/iOS/UAUnityPlugin.m
@@ -37,6 +37,28 @@ static dispatch_once_t onceToken_;
     [UAirship push].pushNotificationDelegate = [UAUnityPlugin shared];
     [UAirship push].registrationDelegate = [UAUnityPlugin shared];
 
+    // Check if the config specified default foreground presentation options
+    UAConfig *airshipConfig = [UAirship shared].config;
+    NSDictionary *customOptions = [airshipConfig customConfig];
+
+    if (customOptions) {
+        UNNotificationPresentationOptions options = UNNotificationPresentationOptionNone;
+
+        if ([customOptions[@"notificationPresentationOptionAlert"] boolValue]) {
+            options = options | UNNotificationPresentationOptionAlert;
+        }
+        if ([customOptions[@"notificationPresentationOptionBadge"] boolValue]) {
+            options = options | UNNotificationPresentationOptionBadge;
+        }
+        if ([customOptions[@"notificationPresentationOptionSound"] boolValue]) {
+            options = options | UNNotificationPresentationOptionSound;
+        }
+
+        UA_LDEBUG(@"Foreground presentation options from the config: %lu", (unsigned long)options);
+
+        [UAirship push].defaultPresentationOptions = options;
+    }
+
     UAAction *customDLA = [UAAction actionWithBlock: ^(UAActionArguments *args, UAActionCompletionHandler handler)  {
         UA_LDEBUG(@"Setting dl to: %@", args.value);
         [UAUnityPlugin shared].storedDeepLink = args.value;

--- a/Assets/UrbanAirship/Editor/UAConfig.cs
+++ b/Assets/UrbanAirship/Editor/UAConfig.cs
@@ -51,6 +51,15 @@ namespace UrbanAirship.Editor
 		public string GCMSenderId { get; set; }
 
 		[SerializeField]
+		public bool NotificationPresentationOptionAlert { get; set; }
+
+		[SerializeField]
+		public bool NotificationPresentationOptionBadge { get; set; }
+
+		[SerializeField]
+		public bool NotificationPresentationOptionSound { get; set; }
+
+		[SerializeField]
 		public bool InProduction { get; set; }
 
 		[SerializeField]
@@ -87,6 +96,11 @@ namespace UrbanAirship.Editor
 			this.DevelopmentLogLevel = config.DevelopmentLogLevel;
 
 			this.InProduction = config.InProduction;
+
+			this.NotificationPresentationOptionAlert = config.NotificationPresentationOptionAlert;
+			this.NotificationPresentationOptionBadge = config.NotificationPresentationOptionBadge;
+			this.NotificationPresentationOptionSound = config.NotificationPresentationOptionSound;
+
 			this.GCMSenderId = config.GCMSenderId;
 			this.AndroidNotificationAccentColor = config.AndroidNotificationAccentColor;
 			this.AndroidNotificationIcon = config.AndroidNotificationIcon;
@@ -175,7 +189,7 @@ namespace UrbanAirship.Editor
 				rootDict.SetString ("productionAppSecret", ProductionAppSecret);
 				rootDict.SetInteger ("productionLogLevel", IOSLogLevel (ProductionLogLevel));
 			}
-				
+
 			if (!String.IsNullOrEmpty (DevelopmentAppKey) && !String.IsNullOrEmpty (DevelopmentAppSecret)) {
 				rootDict.SetString ("developmentAppKey", DevelopmentAppKey);
 				rootDict.SetString ("developmentAppSecret", DevelopmentAppSecret);
@@ -183,6 +197,11 @@ namespace UrbanAirship.Editor
 			}
 
 			rootDict.SetBoolean ("inProduction", InProduction);
+
+			PlistElementDict customConfig = rootDict.CreateDict ("customConfig");
+			customConfig.SetBoolean ("notificationPresentationOptionAlert", NotificationPresentationOptionAlert);
+			customConfig.SetBoolean ("notificationPresentationOptionBadge", NotificationPresentationOptionBadge);
+			customConfig.SetBoolean ("notificationPresentationOptionSound", NotificationPresentationOptionSound);
 
 			File.WriteAllText (plistPath, plist.WriteToString ());
 		}
@@ -198,7 +217,7 @@ namespace UrbanAirship.Editor
 			if (!Directory.Exists (xml)) {
 				Directory.CreateDirectory (xml);
 			}
-	
+
 			using (XmlWriter xmlWriter = XmlWriter.Create (Path.Combine (xml, "airship_config.xml"))) {
 				xmlWriter.WriteStartDocument ();
 				xmlWriter.WriteStartElement ("AirshipConfigOptions");

--- a/Assets/UrbanAirship/Editor/UAConfigEditor.cs
+++ b/Assets/UrbanAirship/Editor/UAConfigEditor.cs
@@ -37,6 +37,10 @@ namespace UrbanAirship.Editor
 				config.DevelopmentLogLevel = (UAConfig.LogLevel) EditorGUILayout.EnumPopup("Log level:", config.DevelopmentLogLevel);
 			});
 
+			CreateSection ("In Production", () => {
+				config.InProduction = EditorGUILayout.Toggle ("inProduction", config.InProduction);
+			});
+
 			CreateSection ("Android", () => {
 				config.GCMSenderId = EditorGUILayout.TextField ("GCM Sender ID", config.GCMSenderId);
 				config.AndroidNotificationAccentColor = EditorGUILayout.TextField ("Notification Accent Color", config.AndroidNotificationAccentColor);
@@ -50,8 +54,11 @@ namespace UrbanAirship.Editor
 				"providing a new Android library project.", EditorStyles.wordWrappedMiniLabel);
 			});
 
-
-			config.InProduction = EditorGUILayout.Toggle ("inProduction", config.InProduction);
+			CreateSection ("Default Foreground Presentation Options for iOS 10+", () => {
+				config.NotificationPresentationOptionAlert = EditorGUILayout.Toggle ("Alert", config.NotificationPresentationOptionAlert);
+				config.NotificationPresentationOptionBadge = EditorGUILayout.Toggle ("Badge", config.NotificationPresentationOptionBadge);
+				config.NotificationPresentationOptionSound = EditorGUILayout.Toggle ("Sound", config.NotificationPresentationOptionSound);
+			});
 
 			GUILayout.FlexibleSpace ();
 


### PR DESCRIPTION
Added iOS foreground presentation support through the config.

Default foreground presentation options for iOS 10+ is available via `Window > Urban Airship > Settings`.

![mb-1975-unity-ua-config-public](https://cloud.githubusercontent.com/assets/3409505/19056312/4120ddc2-897d-11e6-9d06-1aa4d1b1cd14.png)

The generated `AirshipConfig.plist` will contain the saved settings from above ^ as a customConfig

![mb-1975-unity-airship-config-plist-options-6-public](https://cloud.githubusercontent.com/assets/3409505/19056419/f0f768b0-897d-11e6-86fb-f9577d0dc1bb.png)

Testing:
* Receieved push notification with alert, badge & sound while app is in foreground on iOS 10.0.2 iPod.
