### PR TITLE
[CE-2614] Remove iOS build requirement

### DIFF
--- a/Assets/UrbanAirship/Editor/UAConfig.cs
+++ b/Assets/UrbanAirship/Editor/UAConfig.cs
@@ -16,6 +16,7 @@ using UnityEditor.iOS.Xcode;
 namespace UrbanAirship.Editor
 {
 
+        [InitializeOnLoad]
 	[Serializable]
 	public class UAConfig
 	{
@@ -32,6 +33,11 @@ namespace UrbanAirship.Editor
 
 		private static readonly string filePath = "ProjectSettings/UrbanAirship.xml";
 		private static UAConfig cachedInstance;
+
+                static UAConfig ()
+                {
+                    LoadConfig (). Apply ();
+                }
 
 		[SerializeField]
 		public string ProductionAppKey { get; set; }

--- a/Assets/UrbanAirship/Editor/UAConfig.cs
+++ b/Assets/UrbanAirship/Editor/UAConfig.cs
@@ -16,7 +16,7 @@ using UnityEditor.iOS.Xcode;
 namespace UrbanAirship.Editor
 {
 
-        [InitializeOnLoad]
+	[InitializeOnLoad]
 	[Serializable]
 	public class UAConfig
 	{
@@ -34,10 +34,10 @@ namespace UrbanAirship.Editor
 		private static readonly string filePath = "ProjectSettings/UrbanAirship.xml";
 		private static UAConfig cachedInstance;
 
-                static UAConfig ()
-                {
-                    LoadConfig (). Apply ();
-                }
+		static UAConfig ()
+		{
+		    LoadConfig (). Apply ();
+		}
 
 		[SerializeField]
 		public string ProductionAppKey { get; set; }
@@ -154,11 +154,11 @@ namespace UrbanAirship.Editor
 		{
 			if (IsValid) {
 #if UNITY_IOS
-				    GenerateIOSAirshipConfig ();
+				GenerateIOSAirshipConfig ();
 #endif
 
 #if UNITY_ANDROID
-				    GenerateAndroidAirshipConfig ();
+				GenerateAndroidAirshipConfig ();
 #endif
 				return true;
 			}

--- a/Assets/UrbanAirship/Editor/UAConfig.cs
+++ b/Assets/UrbanAirship/Editor/UAConfig.cs
@@ -6,12 +6,16 @@ using System;
 using UnityEngine;
 using System.IO;
 using System.Xml.Serialization;
-using UnityEditor.iOS.Xcode;
 using UnityEditor;
 using System.Xml;
 
+#if UNITY_IOS
+using UnityEditor.iOS.Xcode;
+#endif
+
 namespace UrbanAirship.Editor
 {
+
 	[Serializable]
 	public class UAConfig
 	{
@@ -143,8 +147,13 @@ namespace UrbanAirship.Editor
 		public bool Apply ()
 		{
 			if (IsValid) {
-				GenerateIOSAirshipConfig ();
-				GenerateAndroidAirshipConfig ();
+#if UNITY_IOS
+				    GenerateIOSAirshipConfig ();
+#endif
+
+#if UNITY_ANDROID
+				    GenerateAndroidAirshipConfig ();
+#endif
 				return true;
 			}
 
@@ -172,7 +181,7 @@ namespace UrbanAirship.Editor
 			}
 		}
 
-
+#if UNITY_IOS
 		private void GenerateIOSAirshipConfig ()
 		{
 			string plistPath = Path.Combine (Application.dataPath, "Plugins/iOS/AirshipConfig.plist");
@@ -205,6 +214,7 @@ namespace UrbanAirship.Editor
 
 			File.WriteAllText (plistPath, plist.WriteToString ());
 		}
+#endif
 
 		private void GenerateAndroidAirshipConfig ()
 		{

--- a/Assets/UrbanAirship/Editor/UAPostBuild.cs
+++ b/Assets/UrbanAirship/Editor/UAPostBuild.cs
@@ -3,7 +3,6 @@
 */
 using System;
 
-#if UNITY_IPHONE || UNITY_ANDROID
 
 using UnityEngine;
 using UnityEditor;
@@ -11,7 +10,10 @@ using UnityEditor.Callbacks;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+
+#if UNITY_IOS
 using UnityEditor.iOS.Xcode;
+#endif
 
 namespace UrbanAirship.Editor
 {
@@ -27,15 +29,18 @@ namespace UrbanAirship.Editor
 				EditorUtility.DisplayDialog("Urban Airship", "Urban Airship not configured. Set the app credentials in Window -> Urban Airship -> Settings", "OK");
 			}
 
+#if UNITY_IOS
 			if (target == BuildTarget.iOS)
 			{
 				UpdatePbxProject(buildPath + "/Unity-iPhone.xcodeproj/project.pbxproj", buildPath);
 				UpdateProjectPlist(buildPath + "/Info.plist");
 			}
+#endif
 
 			UnityEngine.Debug.Log("Finished Urban Airship post build steps.");
 		}
 
+#if UNITY_IOS
 		private static void UpdatePbxProject(string projectPath, string buildPath)
 		{
 			PBXProject proj = new PBXProject();
@@ -95,7 +100,7 @@ namespace UrbanAirship.Editor
 
 			File.WriteAllText(plistPath, plist.WriteToString());
 		}
+#endif
 	}
 }
 
-#endif

--- a/Assets/UrbanAirship/Platforms/UAirship.cs
+++ b/Assets/UrbanAirship/Platforms/UAirship.cs
@@ -66,7 +66,7 @@ namespace UrbanAirship {
 			} else {
 				#if UNITY_ANDROID
 				plugin = new UAirshipPluginAndroid ();
-				#elif UNITY_IPHONE
+				#elif UNITY_IOS
 				plugin = new UAirshipPluginIOS ();
 				#else
 				plugin = new StubbedPlugin ();

--- a/Assets/UrbanAirship/Platforms/iOS/UAirshipPluginIOS.cs
+++ b/Assets/UrbanAirship/Platforms/iOS/UAirshipPluginIOS.cs
@@ -2,7 +2,7 @@
  Copyright 2017 Urban Airship and Contributors
 */
 
-#if UNITY_IPHONE
+#if UNITY_IOS
 
 using UnityEngine;
 using System;
@@ -211,4 +211,4 @@ namespace UrbanAirship {
 
 #endif
 
-	
+


### PR DESCRIPTION
Makes it so the plugin does not require installation of the iOS platform. For the config regeneration stuff, I tested:

1. Settings changes that occur while Android is the build target are picked up upon switching platforms to iOS (and vice versa)
2. If a config doesn't exist, switching to that platform will automatically generate the config.