### PR TITLE
Release 4.2.0

### DIFF
--- a/Assets/UrbanAirship/Editor/UADependencies.cs
+++ b/Assets/UrbanAirship/Editor/UADependencies.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEditor;
+using UrbanAirship;
 
 namespace UrbanAirship.Editor
 {
@@ -59,14 +60,14 @@ namespace UrbanAirship.Editor
 
 			Google.VersionHandler.InvokeInstanceMethod(
 				svcSupport, "DependOn",
-				new object[] { "com.android.support", "support-v4", "25.3.1" },
+				new object[] { "com.android.support", "support-v4", PluginInfo.AndroidSupportLibVersion },
 				namedArgs: new Dictionary<string, object>() {
 					{"packageIds", new string[] { "extra-android-m2repository" } }
 				});
 
 			Google.VersionHandler.InvokeInstanceMethod(
 				svcSupport, "DependOn",
-				new object[] { "com.google.android.gms", "play-services-gcm", "10.2.1" },
+				new object[] { "com.google.android.gms", "play-services-gcm", PluginInfo.AndroidPlayServicesVersion },
 				namedArgs: new Dictionary<string, object>() {
 					{"packageIds", new string[] { "extra-android-m2repository" } }
 				});
@@ -95,7 +96,7 @@ namespace UrbanAirship.Editor
 				iosResolver, "AddPod",
 				new object[] { "UrbanAirship-iOS-SDK" },
 				namedArgs: new Dictionary<string, object>() {
-					{ "version", "8.3.3" },
+					{ "version", PluginInfo.IOSAirsipVersion },
 				});
 		}
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 UA Unity ChangeLog
 ==================
 
+Version 4.2.0 - August 10, 2017
+===============================
+ - Updated Urban Airship iOS SDK to 8.5.2
+ - Updated Urban Airship Android SDK to 8.8.1
+
 Version 4.1.0 - June 22, 2017
 =============================
  - Updated Urban Airship Android SDK to 8.6.0 (Android O support)

--- a/airship.properties
+++ b/airship.properties
@@ -1,11 +1,11 @@
 # Plugin version
-version = 4.1.0
+version = 4.2.0
 
 # Urban Airship iOS SDK version
-iosAirshipVersion = 8.3.3
+iosAirshipVersion = 8.5.2
 
 # Urban Airship Android SDK version
-androidAirshipVersion = 8.6.0
+androidAirshipVersion = 8.8.1
 
 # Android Support Library Version
 androidSupportLibVersion = 25.3.1


### PR DESCRIPTION
Note: we are currently unable to bump the play services or the support library, because the jar resolver doesn't pull those dependencies yet.