### PR TITLE
[MB-2418] Fix plugin warnings

### DIFF
--- a/Assets/UrbanAirship/Platforms/CustomEvent.cs
+++ b/Assets/UrbanAirship/Platforms/CustomEvent.cs
@@ -25,8 +25,12 @@ namespace UrbanAirship
 		private string interactionType;
 		[SerializeField]
 		private string interactionId;
+
+		#pragma warning disable
+		// Used for JSON encoding/decoding.
 		[SerializeField]
 		private Property[] properties;
+		#pragma warning restore
 
 		private List<Property> propertyList;
 

--- a/Assets/UrbanAirship/Platforms/PushMessage.cs
+++ b/Assets/UrbanAirship/Platforms/PushMessage.cs
@@ -23,11 +23,16 @@ namespace UrbanAirship
 
 		private Dictionary<string, string> extrasDictionary;
 
+
 		[Serializable]
 		class Extra
 		{
+			#pragma warning disable
+			// Used for JSON encoding/decoding
 			public string key;
 			public string value;
+			#pragma warning restore
+
 		}
 
 		/// <summary>

--- a/Assets/UrbanAirship/Platforms/TagGroupEditor.cs
+++ b/Assets/UrbanAirship/Platforms/TagGroupEditor.cs
@@ -86,6 +86,9 @@ namespace UrbanAirship
 		[Serializable]
 		internal class TagGroupOperation
 		{
+			#pragma warning disable
+			// Used for JSON encoding/decoding
+
 			[SerializeField]
 			private string operation;
 
@@ -94,6 +97,7 @@ namespace UrbanAirship
 
 			[SerializeField]
 			private string[] tags;
+			#pragma warning restore
 
 			public TagGroupOperation (string operation, string tagGroup, ICollection<string> tags)
 			{

--- a/Assets/UrbanAirship/Platforms/UAirship.cs
+++ b/Assets/UrbanAirship/Platforms/UAirship.cs
@@ -15,7 +15,6 @@ namespace UrbanAirship {
 	/// </summary>
 	public class UAirship
 	{
-		private UrbanAirshipListener listener;
 		private IUAirshipPlugin plugin = null;
 
 		/// <summary>
@@ -74,7 +73,8 @@ namespace UrbanAirship {
 			}
 
 			GameObject gameObject = new GameObject("[UrbanAirshipListener]");
-			listener = gameObject.AddComponent<UrbanAirshipListener>();
+			gameObject.AddComponent<UrbanAirshipListener>();
+
 			MonoBehaviour.DontDestroyOnLoad(gameObject);
 			plugin.Listener = gameObject;
 		}


### PR DESCRIPTION
Fixes some warnings around our JSON encoding/decoding work arounds. The UAListener pointed to the component we added, but the field was never used. Seems ok to delete. AddComponent stores a reference the object.