### PR TITLE
[MB-2421] Expose prod and dev FCM sender ID settings

### DIFF
--- a/Assets/UrbanAirship/Editor/UAConfig.cs
+++ b/Assets/UrbanAirship/Editor/UAConfig.cs
@@ -58,7 +58,14 @@ namespace UrbanAirship.Editor
 		public LogLevel DevelopmentLogLevel { get; set; }
 
 		[SerializeField]
-		public string GCMSenderId { get; set; }
+		public string GCMSenderId { get; private set; }
+
+		[SerializeField]
+		public string ProductionFCMSenderId { get; set; }
+
+		[SerializeField]
+		public string DevelopmentFCMSenderId { get; set; }
+
 
 		[SerializeField]
 		public bool NotificationPresentationOptionAlert { get; set; }
@@ -111,7 +118,8 @@ namespace UrbanAirship.Editor
 			this.NotificationPresentationOptionBadge = config.NotificationPresentationOptionBadge;
 			this.NotificationPresentationOptionSound = config.NotificationPresentationOptionSound;
 
-			this.GCMSenderId = config.GCMSenderId;
+			this.ProductionFCMSenderId = config.ProductionFCMSenderId;
+			this.DevelopmentFCMSenderId = config.DevelopmentFCMSenderId;
 			this.AndroidNotificationAccentColor = config.AndroidNotificationAccentColor;
 			this.AndroidNotificationIcon = config.AndroidNotificationIcon;
 		}
@@ -123,6 +131,7 @@ namespace UrbanAirship.Editor
 					using (Stream fileStream = File.OpenRead (filePath)) {
 						XmlSerializer serializer = new XmlSerializer (typeof(UAConfig));
 						UAConfig config = (UAConfig)serializer.Deserialize (fileStream);
+						config.Migrate ();
 						config.Validate ();
 						cachedInstance = config;
 					}
@@ -184,6 +193,15 @@ namespace UrbanAirship.Editor
 				if (string.IsNullOrEmpty (DevelopmentAppSecret)) {
 					throw new Exception ("Development App Secret missing.");
 				}
+			}
+		}
+
+		public void Migrate()
+		{
+			if (GCMSenderId != null) {
+				DevelopmentFCMSenderId = GCMSenderId;
+				ProductionFCMSenderId = GCMSenderId;
+				GCMSenderId = null;
 			}
 		}
 
@@ -261,8 +279,13 @@ namespace UrbanAirship.Editor
 					xmlWriter.WriteAttributeString ("notificationAccentColor", AndroidNotificationAccentColor);
 				}
 
-				if (!String.IsNullOrEmpty (GCMSenderId)) {
-					xmlWriter.WriteAttributeString ("gcmSender", GCMSenderId);
+				if (!String.IsNullOrEmpty (DevelopmentFCMSenderId)) {
+					xmlWriter.WriteAttributeString ("developmentFcmSenderId", DevelopmentFCMSenderId);
+				}
+
+
+				if (!String.IsNullOrEmpty (ProductionFCMSenderId)) {
+					xmlWriter.WriteAttributeString ("productionFcmSenderId", ProductionFCMSenderId);
 				}
 
 				xmlWriter.WriteEndElement ();

--- a/Assets/UrbanAirship/Editor/UAConfigEditor.cs
+++ b/Assets/UrbanAirship/Editor/UAConfigEditor.cs
@@ -29,6 +29,8 @@ namespace UrbanAirship.Editor
 				config.ProductionAppKey = EditorGUILayout.TextField ("App Key", config.ProductionAppKey);
 				config.ProductionAppSecret = EditorGUILayout.TextField ("App Secret", config.ProductionAppSecret);
 				config.ProductionLogLevel = (UAConfig.LogLevel) EditorGUILayout.EnumPopup("Log level:", config.ProductionLogLevel);
+				config.ProductionFCMSenderId = EditorGUILayout.TextField ("Android FCM Sender ID:", config.ProductionFCMSenderId);
+
 			});
 
 
@@ -36,26 +38,27 @@ namespace UrbanAirship.Editor
 				config.DevelopmentAppKey = EditorGUILayout.TextField ("App Key", config.DevelopmentAppKey);
 				config.DevelopmentAppSecret = EditorGUILayout.TextField ("App Secret", config.DevelopmentAppSecret);
 				config.DevelopmentLogLevel = (UAConfig.LogLevel) EditorGUILayout.EnumPopup("Log level:", config.DevelopmentLogLevel);
+				config.DevelopmentFCMSenderId = EditorGUILayout.TextField ("Android FCM Sender ID:", config.DevelopmentFCMSenderId);
+
 			});
 
 			CreateSection ("In Production", () => {
 				config.InProduction = EditorGUILayout.Toggle ("inProduction", config.InProduction);
 			});
 
-			CreateSection ("Android", () => {
-				config.GCMSenderId = EditorGUILayout.TextField ("GCM Sender ID", config.GCMSenderId);
+			CreateSection ("Android Notifications", () => {
 				config.AndroidNotificationAccentColor = EditorGUILayout.TextField ("Notification Accent Color", config.AndroidNotificationAccentColor);
 				config.AndroidNotificationIcon = EditorGUILayout.TextField ("Notification Icon", config.AndroidNotificationIcon);
 
 				GUILayout.Space (5);
 
-				GUILayout.Label ("Notification icon must be a reference to a drawable in the project, e.g., " +
-				"@drawable/app_icon, @android:drawable/ic_dialog_alert. Drawables can be added " +
-				"in either the Assets/Plugins/Android/urbanairship-plugin-lib/res directory or by " +
+				GUILayout.Label ("Notification icon must be the name of a drawable in the project, e.g., " +
+				"app_icon, ic_dialog_alert. Drawables can be added " +
+				"in either the Assets/Plugins/Android/urbanairship-resources/res/drawable* directory or by " +
 				"providing a new Android library project.", EditorStyles.wordWrappedMiniLabel);
 			});
 
-			CreateSection ("Default Foreground Presentation Options for iOS 10+", () => {
+			CreateSection ("iOS Foreground Presentation Options", () => {
 				config.NotificationPresentationOptionAlert = EditorGUILayout.Toggle ("Alert", config.NotificationPresentationOptionAlert);
 				config.NotificationPresentationOptionBadge = EditorGUILayout.Toggle ("Badge", config.NotificationPresentationOptionBadge);
 				config.NotificationPresentationOptionSound = EditorGUILayout.Toggle ("Sound", config.NotificationPresentationOptionSound);
@@ -95,7 +98,7 @@ namespace UrbanAirship.Editor
 		{
 			GUILayout.Label (sectionTitle, EditorStyles.boldLabel);
 			GUILayout.BeginHorizontal ();
-			GUILayout.Space (15);
+			GUILayout.Space (20);
 			GUILayout.BeginVertical ();
 
 			body ();
@@ -103,7 +106,7 @@ namespace UrbanAirship.Editor
 			GUILayout.EndVertical ();
 			GUILayout.Space (5);
 			GUILayout.EndHorizontal ();
-			GUILayout.Space (15);
+			GUILayout.Space (20);
 		}
 	}
 }


### PR DESCRIPTION
When the config is loaded it will auto migrate the gcm to prod and dev.

<img width="798" alt="screen shot 2017-09-28 at 3 11 11 pm" src="https://user-images.githubusercontent.com/3967591/30992555-4d6c8ed4-a45f-11e7-9c64-0c22934951d1.png">
