### PR TITLE
[MB-2422] Fix replacing UIBackgroundModes in the plist every build

### DIFF
--- a/Assets/UrbanAirship/Editor/UAPostBuild.cs
+++ b/Assets/UrbanAirship/Editor/UAPostBuild.cs
@@ -72,8 +72,16 @@ namespace UrbanAirship.Editor
 			PlistDocument plist = new PlistDocument();
 			plist.ReadFromString(File.ReadAllText(plistPath));
 
+
 			PlistElementDict rootDict = plist.root;
-			rootDict.CreateArray("UIBackgroundModes").AddString("remote-notification");
+			if (rootDict ["UIBackgroundModes"] == null) {
+				rootDict.CreateArray ("UIBackgroundModes");
+			}
+
+			PlistElementArray backgroundModes = rootDict ["UIBackgroundModes"].AsArray ();
+			if (backgroundModes.values.Find ((m) => "remote-data" == m.AsString ()) == null) {
+				backgroundModes.AddString("remote-data");
+			}
 
 			File.WriteAllText(plistPath, plist.WriteToString());
 		}


### PR DESCRIPTION
Checks for the existence of background modes and remote data before adding anything. 