### PR TITLE
[CUSTENG-104] Fix Android tag group issue

### DIFF
--- a/unity-plugin/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
+++ b/unity-plugin/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
@@ -380,7 +380,9 @@ public class UnityPlugin {
 
             HashSet<String> tagSet = new HashSet<>();
             for (JsonValue tag : tags) {
-                tagSet.add(tag.toString());
+                if (tag.isString()) {
+                    tagSet.add(tag.getString());
+                }
             }
 
             switch (operationType) {


### PR DESCRIPTION
Fix tag group tags having quotes around them on Android. Fix was to use the `getString()` instead of `toString()`. 