### PR TITLE
[MOBILE-522-iOS] Unity: Clean up cruft in “clean” step

### DIFF
--- a/Assets/UrbanAirship/Editor/UAConfig.cs
+++ b/Assets/UrbanAirship/Editor/UAConfig.cs
@@ -114,6 +114,8 @@ namespace UrbanAirship.Editor {
             this.NotificationPresentationOptionBadge = config.NotificationPresentationOptionBadge;
             this.NotificationPresentationOptionSound = config.NotificationPresentationOptionSound;
 
+            this.ProductionFCMSenderId = config.ProductionFCMSenderId;
+            this.DevelopmentFCMSenderId = config.DevelopmentFCMSenderId;
             this.AndroidNotificationAccentColor = config.AndroidNotificationAccentColor;
             this.AndroidNotificationIcon = config.AndroidNotificationIcon;
             this.GenerateGoogleJsonConfig = config.GenerateGoogleJsonConfig;
@@ -212,6 +214,8 @@ namespace UrbanAirship.Editor {
             }
 
             if (GCMSenderId != null) {
+                DevelopmentFCMSenderId = GCMSenderId;
+                ProductionFCMSenderId = GCMSenderId;
                 GCMSenderId = null;
             }
 

--- a/Assets/UrbanAirship/Editor/UAConfig.cs
+++ b/Assets/UrbanAirship/Editor/UAConfig.cs
@@ -22,6 +22,7 @@ namespace UrbanAirship.Editor {
             Debug = 1,
             Info = 2,
             Warn = 3,
+            Warning = -1,
             Error = 4,
             None = 5
         }
@@ -48,7 +49,7 @@ namespace UrbanAirship.Editor {
         public LogLevel DevelopmentLogLevel { get; set; }
 
         [SerializeField]
-        public string GCMSenderId { get; private set; }
+        public string GCMSenderId { get; set; }
 
         [SerializeField]
         public string ProductionFCMSenderId { get; set; }
@@ -113,8 +114,6 @@ namespace UrbanAirship.Editor {
             this.NotificationPresentationOptionBadge = config.NotificationPresentationOptionBadge;
             this.NotificationPresentationOptionSound = config.NotificationPresentationOptionSound;
 
-            this.ProductionFCMSenderId = config.ProductionFCMSenderId;
-            this.DevelopmentFCMSenderId = config.DevelopmentFCMSenderId;
             this.AndroidNotificationAccentColor = config.AndroidNotificationAccentColor;
             this.AndroidNotificationIcon = config.AndroidNotificationIcon;
             this.GenerateGoogleJsonConfig = config.GenerateGoogleJsonConfig;
@@ -125,23 +124,29 @@ namespace UrbanAirship.Editor {
                 return new UAConfig (cachedInstance);
             }
 
+            bool migratedConfig = false;
             try {
                 if (File.Exists (filePath)) {
                     using (Stream fileStream = File.OpenRead (filePath)) {
                         XmlSerializer serializer = new XmlSerializer (typeof (UAConfig));
                         UAConfig config = (UAConfig) serializer.Deserialize (fileStream);
-                        config.Migrate ();
+                        migratedConfig = config.Migrate ();
                         config.Validate ();
                         cachedInstance = config;
                     }
                 }
             } catch (Exception e) {
-                UnityEngine.Debug.Log ("Failed to load UAConfig: " + e.Message);
+                UnityEngine.Debug.Log ("UAConfig: Failed to load config: " + e.Message);
                 File.Delete (filePath);
             }
 
             if (cachedInstance == null) {
                 cachedInstance = new UAConfig ();
+            }
+
+            if (migratedConfig) {
+                UnityEngine.Debug.Log ("UAConfig: saving config");
+                SaveConfig(cachedInstance);
             }
 
             return new UAConfig (cachedInstance);
@@ -193,18 +198,36 @@ namespace UrbanAirship.Editor {
             }
         }
 
-        public void Migrate () {
+        public bool Migrate () {
+             if (Version == null) {
+                UnityEngine.Debug.Log ("UAConfig: migrating pre-versioned config to version " + PluginInfo.Version);
+                GenerateGoogleJsonConfig = true;
+                Version = PluginInfo.Version;
+            } else if (Version != PluginInfo.Version) {
+                UnityEngine.Debug.Log ("UAConfig: migrating from version " + Version + " to version " + PluginInfo.Version);
+                Version = PluginInfo.Version;
+            } else {
+                UnityEngine.Debug.Log("UAConfig: no migration needed. Version already " + Version);
+                return false;
+            }
+
             if (GCMSenderId != null) {
-                DevelopmentFCMSenderId = GCMSenderId;
-                ProductionFCMSenderId = GCMSenderId;
                 GCMSenderId = null;
             }
 
-            if (Version == null) {
-                GenerateGoogleJsonConfig = true;
+            // migrate to new log levels
+            if (ProductionLogLevel == LogLevel.Warning) {
+                UnityEngine.Debug.Log ("UAConfig: migrating obsolete Production Log Level = Warning to Warn");
+                ProductionLogLevel = LogLevel.Warn;
+            }
+            if (DevelopmentLogLevel == LogLevel.Warning) {
+                UnityEngine.Debug.Log ("UAConfig: migrating obsolete Development Log Level = Warning to Warn");
+                DevelopmentLogLevel = LogLevel.Warn;
             }
 
-            Version = PluginInfo.Version;
+            UnityEngine.Debug.Log ("UAConfig: migrated to version " + Version);
+
+            return true;
         }
 
 #if UNITY_IOS
@@ -318,7 +341,8 @@ namespace UrbanAirship.Editor {
                 case LogLevel.Info:
                     return 3;
                 case LogLevel.Warn:
-                    return 2;
+                case LogLevel.Warning:
+                     return 2;
                 case LogLevel.Error:
                     return 1;
                 case LogLevel.None:

--- a/Assets/UrbanAirship/Editor/UAConfigEditor.cs
+++ b/Assets/UrbanAirship/Editor/UAConfigEditor.cs
@@ -24,14 +24,12 @@ namespace UrbanAirship.Editor {
                 config.ProductionAppKey = EditorGUILayout.TextField ("App Key", config.ProductionAppKey);
                 config.ProductionAppSecret = EditorGUILayout.TextField ("App Secret", config.ProductionAppSecret);
                 config.ProductionLogLevel = (UAConfig.LogLevel) EditorGUILayout.EnumPopup ("Log level:", config.ProductionLogLevel);
-                config.ProductionFCMSenderId = EditorGUILayout.TextField ("Android FCM Sender ID:", config.ProductionFCMSenderId);
             });
 
             CreateSection ("Development", () => {
                 config.DevelopmentAppKey = EditorGUILayout.TextField ("App Key", config.DevelopmentAppKey);
                 config.DevelopmentAppSecret = EditorGUILayout.TextField ("App Secret", config.DevelopmentAppSecret);
                 config.DevelopmentLogLevel = (UAConfig.LogLevel) EditorGUILayout.EnumPopup ("Log level:", config.DevelopmentLogLevel);
-                config.DevelopmentFCMSenderId = EditorGUILayout.TextField ("Android FCM Sender ID:", config.DevelopmentFCMSenderId);
             });
 
             CreateSection ("In Production", () => {

--- a/Assets/UrbanAirship/Editor/UAConfigEditor.cs
+++ b/Assets/UrbanAirship/Editor/UAConfigEditor.cs
@@ -24,12 +24,14 @@ namespace UrbanAirship.Editor {
                 config.ProductionAppKey = EditorGUILayout.TextField ("App Key", config.ProductionAppKey);
                 config.ProductionAppSecret = EditorGUILayout.TextField ("App Secret", config.ProductionAppSecret);
                 config.ProductionLogLevel = (UAConfig.LogLevel) EditorGUILayout.EnumPopup ("Log level:", config.ProductionLogLevel);
+                config.ProductionFCMSenderId = EditorGUILayout.TextField ("Android FCM Sender ID:", config.ProductionFCMSenderId);
             });
 
             CreateSection ("Development", () => {
                 config.DevelopmentAppKey = EditorGUILayout.TextField ("App Key", config.DevelopmentAppKey);
                 config.DevelopmentAppSecret = EditorGUILayout.TextField ("App Secret", config.DevelopmentAppSecret);
                 config.DevelopmentLogLevel = (UAConfig.LogLevel) EditorGUILayout.EnumPopup ("Log level:", config.DevelopmentLogLevel);
+                config.DevelopmentFCMSenderId = EditorGUILayout.TextField ("Android FCM Sender ID:", config.DevelopmentFCMSenderId);
             });
 
             CreateSection ("In Production", () => {

--- a/Assets/UrbanAirship/Editor/UAUpdater.cs
+++ b/Assets/UrbanAirship/Editor/UAUpdater.cs
@@ -70,6 +70,8 @@ namespace UrbanAirship.Editor {
             if (refreshAssets) {
                 AssetDatabase.Refresh ();
             }
+        }
+        
         /// <summary>
         /// Removes obsolete iOS libraries (libUAirship*).
         /// </summary>

--- a/Assets/UrbanAirship/Editor/UAUpdater.cs
+++ b/Assets/UrbanAirship/Editor/UAUpdater.cs
@@ -24,6 +24,7 @@ namespace UrbanAirship.Editor {
 
             MigrateResources ();
             DeleteObsoleteFiles ();
+            RemoveObsoleteIOSLibraries(PluginInfo.IOSAirshipVersion);
         }
 
         private static void MigrateResources () {
@@ -69,6 +70,33 @@ namespace UrbanAirship.Editor {
             if (refreshAssets) {
                 AssetDatabase.Refresh ();
             }
+        /// <summary>
+        /// Removes obsolete iOS libraries (libUAirship*).
+        /// </summary>
+        /// <param name="keepVersion">iOS library version to keep</param>
+        private static void RemoveObsoleteIOSLibraries(string keepVersion)
+        {
+            Debug.Log("UAUpdater: Removing obsolete iOS libraries");
+
+            string iOSLibraryFolder = "Assets/Plugins/iOS/Airship";
+
+            // get a list of all the libraries in the plugin
+            string[] libraries = Directory.GetFiles(iOSLibraryFolder, "libUAirship*");
+
+            // filter the new library out of the list
+            string[] librariesToRemove = Array.FindAll(libraries, library => !library.Contains(keepVersion));
+
+            if (librariesToRemove.Length == 0) {
+                Debug.Log("UAUpdater: No obsolete libraries to remove");
+                return;
+            }
+
+            foreach (string library in librariesToRemove) {
+                Debug.Log("UAUpdater: Deleting file: " + library);
+                File.Delete(library);
+            }
+
+            Debug.Log("UAUpdater: Removed obsolete iOS libraries");
         }
     }
 }


### PR DESCRIPTION
### What do these changes do?
Fix migration to new version of the plugin for iOS projects. The upgrade process now completes without errors:

1. Download new version of the plugin (urbanairship-X.Y.Z.unitypackage) from bintray.
2. Open existing project in Unity
3. In Unity:
   1. Upgrade to new plugin (As of Unity 2019.1.1f1: "Assets" → "Import Package" → "Custom Package")
   1. Build and Run (As of Unity 2019.1.1f1: "File" → "Build Settings")
      1. If necessary, switch to iOS Platform
      1. Build and Run
      1. _Unity launches Xcode_
8. In Xcode:
   1. if necessary, select a development team.
   9. Run

### Why are these changes necessary?
Developers have reported issues upgrading to new versions of our plugin. 

### How did you verify these changes?
Lots of upgrades of the ua-sample-game project

### Anything else a reviewer should know?
* There was existing migration code. It was just not up-to-date.
* New migration code used existing patterns, or patterns from [GPGSUpgrader.cs](https://github.com/playgameservices/play-games-plugin-for-unity/blob/d8d3267db13878c5e3fefb69c516e15151eba531/source/PluginDev/Assets/GooglePlayGames/Editor/GPGSUpgrader.cs), which is what UAUpdater was originally based on.
* I focused on cross-platform configuration and iOS platform-specific migration for this first PR. Android platform-specific migration will follow.