### PR TITLE
Update jar resolver to 1.2.123

### DIFF
--- a/airship.properties
+++ b/airship.properties
@@ -22,5 +22,5 @@ androidMinSdkVersion = 16
 # Firebase Core
 firebaseCore = 16.0.6
 
-# Google Play Services Resolver SHA https://github.com/googlesamples/unity-jar-resolver
-playServicesResolverSHA = 6ac45e9d5c297fcd4fdcc40d4c696330d0c14357
+# Google Play Services Resolver - v1.2.123
+playServicesResolverSHA = 43d700803aa9e2680d9254ea706a3b6b6c2bc1da


### PR DESCRIPTION
Updates unity jar resolver to 1.2.123. We can switch to tags now but that required more work than just pointing to the sha. Ill create a ticket to do that in the future.