### PR TITLE
[CE-2080] resolve gradle sync error and get android building

### DIFF
--- a/Assets/Plugins/Android/urbanairship-resources/AndroidManifest.xml
+++ b/Assets/Plugins/Android/urbanairship-resources/AndroidManifest.xml
@@ -2,12 +2,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.urbanairship.unityresources" >
 
-    <uses-sdk
-        android:minSdkVersion="16"
-        android:targetSdkVersion="26" />
-
-    <application>
-
-    </application>
 
 </manifest>


### PR DESCRIPTION
Currently running into an issue that resembles this one:
https://github.com/urbanairship/ua-unity-plugin/issues/91

### What do these changes do?
Removes the minSdk and targetSdk version from the urbanairship resources manifest.

### Why are these changes necessary?
![Screen Shot 2019-12-27 at 10 14 23 AM](https://user-images.githubusercontent.com/2199816/71528484-e75b1b80-2894-11ea-8f32-b47d9d0f303e.png)
![Screen Shot 2019-12-27 at 9 03 09 AM](https://user-images.githubusercontent.com/2199816/71528485-e75b1b80-2894-11ea-9dcb-cbc00b10c837.png)
![Screen Shot 2019-12-27 at 9 00 13 AM](https://user-images.githubusercontent.com/2199816/71528486-e75b1b80-2894-11ea-8d66-ec101364683d.png)

### How did you verify these changes?
Set up a test project, installed the plugin, exported the android project, got the project syncing properly without the warning.