### PR TITLE
[MOBILE-1330] add screen tracking to unity

### DIFF
--- a/Assets/Plugins/iOS/UAUnityPlugin.m
+++ b/Assets/Plugins/iOS/UAUnityPlugin.m
@@ -247,7 +247,7 @@ void UAUnityPlugin_addCustomEvent(const char *customEvent) {
 
 void UAUnityPlugin_trackScreen(const char *screenName) {
     NSString *screenNameString = [NSString stringWithUTF8String:screenName];
-    UA_LDEBUG(@"UnityPlugin trackScreen");
+    UA_LDEBUG(@"UnityPlugin trackScreen: %@, screenNameString");
 
     [[UAirship shared].analytics trackScreen:screenNameString];
 }

--- a/Assets/Plugins/iOS/UAUnityPlugin.m
+++ b/Assets/Plugins/iOS/UAUnityPlugin.m
@@ -247,7 +247,7 @@ void UAUnityPlugin_addCustomEvent(const char *customEvent) {
 
 void UAUnityPlugin_trackScreen(const char *screenName) {
     NSString *screenNameString = [NSString stringWithUTF8String:screenName];
-    UA_LDEBUG(@"UnityPlugin trackScreen: %@, screenNameString");
+    UA_LDEBUG(@"UnityPlugin trackScreen: %@", screenNameString);
 
     [[UAirship shared].analytics trackScreen:screenNameString];
 }

--- a/Assets/Plugins/iOS/UAUnityPlugin.m
+++ b/Assets/Plugins/iOS/UAUnityPlugin.m
@@ -203,6 +203,10 @@ void UAUnityPlugin_setBackgroundLocationAllowed(bool enabled) {
     [UALocation sharedLocation].backgroundLocationUpdatesAllowed = enabled ? YES : NO;
 }
 
+
+#pragma mark -
+#pragma mark Analytics
+
 void UAUnityPlugin_addCustomEvent(const char *customEvent) {
     NSString *customEventString = [NSString stringWithUTF8String:customEvent];
     UA_LDEBUG(@"UnityPlugin addCustomEvent");
@@ -239,6 +243,13 @@ void UAUnityPlugin_addCustomEvent(const char *customEvent) {
     }
 
     [[UAirship shared].analytics addEvent:ce];
+}
+
+void UAUnityPlugin_trackScreen(const char *screenName) {
+    NSString *screenNameString = [NSString stringWithUTF8String:screenName];
+    UA_LDEBUG(@"UnityPlugin trackScreen");
+
+    [[UAirship shared].analytics trackScreen:screenNameString];
 }
 
 void UAUnityPlugin_associateIdentifier(const char *key, const char *identifier) {

--- a/Assets/Scripts/UrbanAirshipBehaviour.cs
+++ b/Assets/Scripts/UrbanAirshipBehaviour.cs
@@ -24,6 +24,8 @@ public class UrbanAirshipBehaviour : MonoBehaviour {
         UAirship.Shared.OnInboxUpdated += OnInboxUpdated;
         UAirship.Shared.OnShowInbox += OnShowInbox;
 
+        UAirship.Shared.TrackScreen("Main Camera");
+
         UAirship.Shared.RefreshInbox();
     }
 

--- a/Assets/UrbanAirship/Platforms/Android/UAirshipPluginAndroid.cs
+++ b/Assets/UrbanAirship/Platforms/Android/UAirshipPluginAndroid.cs
@@ -98,6 +98,10 @@ namespace UrbanAirship {
             Call ("addCustomEvent", customEvent);
         }
 
+        public void TrackScreen (string screenName) {
+            Call ("trackScreen", screenName);
+        }
+
         public void AssociateIdentifier (string key, string identifier) {
             Call ("associateIdentifier", key, identifier);
         }

--- a/Assets/UrbanAirship/Platforms/IUAirshipPlugin.cs
+++ b/Assets/UrbanAirship/Platforms/IUAirshipPlugin.cs
@@ -49,6 +49,8 @@ namespace UrbanAirship {
 
         void AddCustomEvent (string customEvent);
 
+        void TrackScreen (string screenName);
+
         void AssociateIdentifier (string key, string identifier);
 
         void DisplayMessageCenter ();

--- a/Assets/UrbanAirship/Platforms/StubbedPlugin.cs
+++ b/Assets/UrbanAirship/Platforms/StubbedPlugin.cs
@@ -17,6 +17,7 @@ namespace UrbanAirship {
         public void AddTag (string tag) { }
         public void RemoveTag (string tag) { }
         public void AddCustomEvent (string customEvent) { }
+        public void TrackScreen(string screenName) { }
         public void AssociateIdentifier (string key, string identifier) { }
         public void DisplayMessageCenter () { }
         public void DisplayInboxMessage (string messageId) { }

--- a/Assets/UrbanAirship/Platforms/UAirship.cs
+++ b/Assets/UrbanAirship/Platforms/UAirship.cs
@@ -251,6 +251,14 @@ namespace UrbanAirship {
         }
 
         /// <summary>
+        /// Adds a screen tracking event to analytics.
+        /// </summary>
+        /// <param name="screenName">The screen name.</param>
+        public void TrackScreen(string screenName) {
+            plugin.TrackScreen(screenName);
+        }
+
+        /// <summary>
         /// Associate a custom identifier.
         /// Previous identifiers will be replaced by the new identifiers each time AssociateIdentifier is called.
         /// It is a set operation.

--- a/Assets/UrbanAirship/Platforms/iOS/UAirshipPluginIOS.cs
+++ b/Assets/UrbanAirship/Platforms/iOS/UAirshipPluginIOS.cs
@@ -51,8 +51,12 @@ namespace UrbanAirship {
         [DllImport ("__Internal")]
         private static extern void UAUnityPlugin_setBackgroundLocationAllowed (bool allowed);
 
+        //Analytics Function Imports
         [DllImport ("__Internal")]
         private static extern void UAUnityPlugin_addCustomEvent (string customEvent);
+
+        [DllImport ("__Internal")]
+        private static extern void UAUnityPlugin_trackScreen (string screenName);
 
         [DllImport ("__Internal")]
         private static extern void UAUnityPlugin_associateIdentifier (string key, string identifier);

--- a/Assets/UrbanAirship/Platforms/iOS/UAirshipPluginIOS.cs
+++ b/Assets/UrbanAirship/Platforms/iOS/UAirshipPluginIOS.cs
@@ -175,6 +175,10 @@ namespace UrbanAirship {
             UAUnityPlugin_addCustomEvent (customEvent);
         }
 
+        public void TrackScreen (string screenName) {
+            UAUnityPlugin_trackScreen (screenName);
+        }
+
         public void AssociateIdentifier (string key, string identifier) {
             UAUnityPlugin_associateIdentifier (key, identifier);
         }

--- a/Assets/UrbanAirship/Platforms/iOS/UAirshipPluginIOS.cs
+++ b/Assets/UrbanAirship/Platforms/iOS/UAirshipPluginIOS.cs
@@ -51,7 +51,7 @@ namespace UrbanAirship {
         [DllImport ("__Internal")]
         private static extern void UAUnityPlugin_setBackgroundLocationAllowed (bool allowed);
 
-        //Analytics Function Imports
+        // Analytics Function Imports
         [DllImport ("__Internal")]
         private static extern void UAUnityPlugin_addCustomEvent (string customEvent);
 

--- a/unity-plugin/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
+++ b/unity-plugin/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
@@ -222,12 +222,12 @@ public class UnityPlugin {
     }
 
     public void trackScreen(String screenName) {
-        PluginLogger.debug("UnityPlugin trackScreen: " + screenName);
-
         if (UAStringUtil.isEmpty(screenName)) {
             PluginLogger.error("Missing screen name");
             return;
         }
+
+        PluginLogger.debug("UnityPlugin trackScreen: " + screenName);
 
         UAirship.shared().getAnalytics().trackScreen(screenName);
     }

--- a/unity-plugin/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
+++ b/unity-plugin/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
@@ -221,6 +221,17 @@ public class UnityPlugin {
         UAirship.shared().getAnalytics().addEvent(eventBuilder.build());
     }
 
+    public void trackScreen(String screenName) {
+        PluginLogger.debug("UnityPlugin trackScreen: " + screenName);
+
+        if (UAStringUtil.isEmpty(screenName)) {
+            PluginLogger.error("Missing screen name");
+            return;
+        }
+
+        UAirship.shared().getAnalytics().trackScreen(screenName);
+    }
+
     public void associateIdentifier(String key, String identifier) {
         if (key == null) {
             PluginLogger.debug("UnityPlugin associateIdentifier failed, key cannot be null");


### PR DESCRIPTION
### What do these changes do?
Add screen tracking to unity.

### Why are these changes necessary?
To add screen tracking to unity and reach functional parity with other plugins.

### How did you verify these changes?
Ran the sample with the unity sample script with onStart screen tracking added. Ensured breakpoint at trackScreen was hit on start when main camera was tracked.

#### Verification Screenshots:
![Screen Shot 2020-02-28 at 4 24 06 PM](https://user-images.githubusercontent.com/2199816/75596748-c48ce500-5a46-11ea-8cdd-1bbc21e74acb.png)

### Anything else a reviewer should know?
<!-- ℹ Please provide any additional notes for the reviewer here. -->
