### PR TITLE
[Mobile 1331]  Add data collection enabled flag to Unity

### DIFF
--- a/Assets/Plugins/iOS/UAUnityPlugin.h
+++ b/Assets/Plugins/iOS/UAUnityPlugin.h
@@ -83,6 +83,11 @@ void UAUnityPlugin_editChannelTagGroups(const char *payload);
 
 void UAUnityPlugin_editChannelAttributes(const char *payload);
 
+#pragma mark -
+#pragma mark Data Collection
+void UAUnityPlugin_setDataCollectionEnabled(bool enabled);
+void UAUnityPlugin_setPushTokenRegistrationEnabled(bool enabled);
+
 @interface UAUnityPlugin : NSObject <UAPushNotificationDelegate, UARegistrationDelegate, UADeepLinkDelegate,  UAMessageCenterDisplayDelegate>
 
 + (UAUnityPlugin *)shared;

--- a/Assets/Plugins/iOS/UAUnityPlugin.h
+++ b/Assets/Plugins/iOS/UAUnityPlugin.h
@@ -85,7 +85,9 @@ void UAUnityPlugin_editChannelAttributes(const char *payload);
 
 #pragma mark -
 #pragma mark Data Collection
+bool UAUnityPlugin_isDataCollectionEnabled();
 void UAUnityPlugin_setDataCollectionEnabled(bool enabled);
+bool UAUnityPlugin_isPushTokenRegistrationEnabled();
 void UAUnityPlugin_setPushTokenRegistrationEnabled(bool enabled);
 
 @interface UAUnityPlugin : NSObject <UAPushNotificationDelegate, UARegistrationDelegate, UADeepLinkDelegate,  UAMessageCenterDisplayDelegate>

--- a/Assets/Plugins/iOS/UAUnityPlugin.m
+++ b/Assets/Plugins/iOS/UAUnityPlugin.m
@@ -576,6 +576,20 @@ void UAUnityPlugin_editChannelAttributes(const char *payload) {
 }
 
 #pragma mark -
+#pragma mark Data Collection
+
+void UAUnityPlugin_setDataCollectionEnabled(bool enabled) {
+    [UAirship shared].dataCollectionEnabled = enabled;
+    UA_LDEBUG(@"UAUnityPlugin_setDataCollectionEnabled %@",[UAUnityPlugin shared].dataCollectionEnabled);
+}
+
+void UAUnityPlugin_setPushTokenRegistrationEnabled(bool enabled) {
+    [[UAPush shared] setPushTokenRegistrationEnabled:enabled];
+    UA_LDEBUG(@"UAUnityPlugin_setPushTokenRegistrationEnabled %@",[UAUnityPlugin shared].pushTokenRegistrationEnabled);
+}
+
+
+#pragma mark -
 #pragma mark Helpers
 
 + (NSString *)stringOrNil:(NSString *)string {

--- a/Assets/Plugins/iOS/UAUnityPlugin.m
+++ b/Assets/Plugins/iOS/UAUnityPlugin.m
@@ -579,13 +579,13 @@ void UAUnityPlugin_editChannelAttributes(const char *payload) {
 #pragma mark Data Collection
 
 void UAUnityPlugin_setDataCollectionEnabled(bool enabled) {
-    [UAirship shared].dataCollectionEnabled = enabled;
-    UA_LDEBUG(@"UAUnityPlugin_setDataCollectionEnabled %@",[UAUnityPlugin shared].dataCollectionEnabled);
+    [[UAirship shared] setDataCollectionEnabled:enabled];
+    UA_LDEBUG(@"UAUnityPlugin_setDataCollectionEnabled %@", @([UAirship shared].dataCollectionEnabled));
 }
 
 void UAUnityPlugin_setPushTokenRegistrationEnabled(bool enabled) {
     [[UAPush shared] setPushTokenRegistrationEnabled:enabled];
-    UA_LDEBUG(@"UAUnityPlugin_setPushTokenRegistrationEnabled %@",[UAUnityPlugin shared].pushTokenRegistrationEnabled);
+    UA_LDEBUG(@"UAUnityPlugin_setPushTokenRegistrationEnabled %@",@([UAPush shared].pushTokenRegistrationEnabled));
 }
 
 

--- a/Assets/Plugins/iOS/UAUnityPlugin.m
+++ b/Assets/Plugins/iOS/UAUnityPlugin.m
@@ -580,14 +580,23 @@ void UAUnityPlugin_editChannelAttributes(const char *payload) {
 
 void UAUnityPlugin_setDataCollectionEnabled(bool enabled) {
     [[UAirship shared] setDataCollectionEnabled:enabled];
-    UA_LDEBUG(@"UAUnityPlugin_setDataCollectionEnabled %@", @([UAirship shared].dataCollectionEnabled));
+    UA_LDEBUG(@"UAUnityPlugin setDataCollectionEnabled %@", @([UAirship shared].dataCollectionEnabled));
+}
+
+bool UAUnityPlugin_isDataCollectionEnabled() {
+    UA_LDEBUG(@"UnityPlugin isDataCollectionEnabled");
+    return [UAirship shared].dataCollectionEnabled ? true : false;
 }
 
 void UAUnityPlugin_setPushTokenRegistrationEnabled(bool enabled) {
     [[UAPush shared] setPushTokenRegistrationEnabled:enabled];
-    UA_LDEBUG(@"UAUnityPlugin_setPushTokenRegistrationEnabled %@",@([UAPush shared].pushTokenRegistrationEnabled));
+    UA_LDEBUG(@"UAUnityPlugin setPushTokenRegistrationEnabled %@",@([UAPush shared].pushTokenRegistrationEnabled));
 }
 
+bool UAUnityPlugin_isPushTokenRegistrationEnabled() {
+    UA_LDEBUG(@"UnityPlugin isPushTokenRegistrationEnabled");
+    return [UAPush shared].pushTokenRegistrationEnabled ? true : false;
+}
 
 #pragma mark -
 #pragma mark Helpers

--- a/Assets/Scripts/UrbanAirshipBehaviour.cs
+++ b/Assets/Scripts/UrbanAirshipBehaviour.cs
@@ -9,6 +9,8 @@ public class UrbanAirshipBehaviour : MonoBehaviour {
     public string addTagOnStart;
 
     void Awake () {
+        UAirship.Shared.DataCollectionEnabled = true;
+        UAirship.Shared.PushTokenRegistrationEnabled = true;
         UAirship.Shared.UserNotificationsEnabled = true;
     }
 

--- a/Assets/UrbanAirship/Editor/UAConfig.cs
+++ b/Assets/UrbanAirship/Editor/UAConfig.cs
@@ -69,6 +69,9 @@ namespace UrbanAirship.Editor {
         public bool InProduction { get; set; }
 
         [SerializeField]
+        public bool DataCollectionOptInEnabled { get; set; }
+
+        [SerializeField]
         public String AndroidNotificationIcon { get; set; }
 
         [SerializeField]
@@ -109,6 +112,8 @@ namespace UrbanAirship.Editor {
             this.DevelopmentLogLevel = config.DevelopmentLogLevel;
 
             this.InProduction = config.InProduction;
+
+            this.DataCollectionOptInEnabled = config.DataCollectionOptInEnabled;
 
             this.NotificationPresentationOptionAlert = config.NotificationPresentationOptionAlert;
             this.NotificationPresentationOptionBadge = config.NotificationPresentationOptionBadge;
@@ -253,6 +258,7 @@ namespace UrbanAirship.Editor {
 
             rootDict.SetString ("site", Site.ToString());
             rootDict.SetBoolean ("inProduction", InProduction);
+            rootDict.SetBoolean ("dataCollectionOptInEnabled", DataCollectionOptInEnabled);
 
             PlistElementDict customConfig = rootDict.CreateDict ("customConfig");
             customConfig.SetBoolean ("notificationPresentationOptionAlert", NotificationPresentationOptionAlert);
@@ -310,6 +316,7 @@ namespace UrbanAirship.Editor {
 
                 xmlWriter.WriteAttributeString ("site", Site.ToString());
                 xmlWriter.WriteAttributeString ("inProduction", (InProduction ? "true" : "false"));
+                xmlWriter.WriteAttributeString ("dataCollectionOptInEnabled", (DataCollectionOptInEnabled ? "true" : "false"));
 
                 if (!String.IsNullOrEmpty (AndroidNotificationIcon)) {
                     xmlWriter.WriteAttributeString ("notificationIcon", AndroidNotificationIcon);

--- a/Assets/UrbanAirship/Editor/UAConfigEditor.cs
+++ b/Assets/UrbanAirship/Editor/UAConfigEditor.cs
@@ -35,7 +35,12 @@ namespace UrbanAirship.Editor {
             CreateSection ("Common", () => {
                 config.InProduction = EditorGUILayout.Toggle ("inProduction", config.InProduction);
                 config.Site = (UAConfig.CloudSite) EditorGUILayout.EnumPopup ("Cloud Site", config.Site);
-                config.DataCollectionOptInEnabled = EditorGUILayout.Toggle ("Data collection optin enabled", config.DataCollectionOptInEnabled);
+                config.DataCollectionOptInEnabled = EditorGUILayout.Toggle ("Data Collection Opt-In", config.DataCollectionOptInEnabled);
+                GUILayout.Label ("When data collection opt-in is enabled, data collection will be disabled by default until the app enables it by calling " +
+                "`UAirship.Shared.DataCollectionEnabled = true`. When disabled, the device will stop collection and sending data for named user, events, tags " +
+                "attributes, associated identifiers, and location from the device. Push notifications will continue to work only if " +
+                "`UAirship.Shared.PushTokenRegistrationEnabled = true` is called, otherwise it will default to the current state of DataCollectionEnabled.",
+                EditorStyles.wordWrappedMiniLabel);
             });
 
             CreateSection ("Android Settings", () => {

--- a/Assets/UrbanAirship/Editor/UAConfigEditor.cs
+++ b/Assets/UrbanAirship/Editor/UAConfigEditor.cs
@@ -35,6 +35,7 @@ namespace UrbanAirship.Editor {
             CreateSection ("Common", () => {
                 config.InProduction = EditorGUILayout.Toggle ("inProduction", config.InProduction);
                 config.Site = (UAConfig.CloudSite) EditorGUILayout.EnumPopup ("Cloud Site", config.Site);
+                config.DataCollectionOptInEnabled = EditorGUILayout.Toggle ("Data collection enabled", config.DataCollectionOptInEnabled);
             });
 
             CreateSection ("Android Settings", () => {

--- a/Assets/UrbanAirship/Editor/UAConfigEditor.cs
+++ b/Assets/UrbanAirship/Editor/UAConfigEditor.cs
@@ -35,7 +35,7 @@ namespace UrbanAirship.Editor {
             CreateSection ("Common", () => {
                 config.InProduction = EditorGUILayout.Toggle ("inProduction", config.InProduction);
                 config.Site = (UAConfig.CloudSite) EditorGUILayout.EnumPopup ("Cloud Site", config.Site);
-                config.DataCollectionOptInEnabled = EditorGUILayout.Toggle ("Data collection enabled", config.DataCollectionOptInEnabled);
+                config.DataCollectionOptInEnabled = EditorGUILayout.Toggle ("Data collection optin enabled", config.DataCollectionOptInEnabled);
             });
 
             CreateSection ("Android Settings", () => {

--- a/Assets/UrbanAirship/Platforms/Android/UAirshipPluginAndroid.cs
+++ b/Assets/UrbanAirship/Platforms/Android/UAirshipPluginAndroid.cs
@@ -188,6 +188,24 @@ namespace UrbanAirship {
             }
             return default (T);
         }
+
+        public bool DataCollectionEnabled {
+            get {
+                return Call<bool> ("isDataCollectionEnabled");
+            }
+            set {
+                Call ("setDataCollectionEnabled", value);
+            }
+        }
+
+        public bool PushTokenRegistrationEnabled {
+            get {
+                return Call<bool> ("isPushTokenRegistrationEnabled");
+            }
+            set {
+                Call ("setPushTokenRegistrationEnabled", value);
+            }
+        }
     }
 }
 

--- a/Assets/UrbanAirship/Platforms/IUAirshipPlugin.cs
+++ b/Assets/UrbanAirship/Platforms/IUAirshipPlugin.cs
@@ -40,6 +40,16 @@ namespace UrbanAirship {
             set;
         }
 
+        bool DataCollectionEnabled {
+            get;
+            set;
+        }
+
+        bool PushTokenRegistrationEnabled {
+            get;
+            set;
+        }
+
         string GetDeepLink (bool clear);
 
         string GetIncomingPush (bool clear);

--- a/Assets/UrbanAirship/Platforms/StubbedPlugin.cs
+++ b/Assets/UrbanAirship/Platforms/StubbedPlugin.cs
@@ -33,5 +33,7 @@ namespace UrbanAirship {
         public void EditNamedUserTagGroups (string payload) { }
         public void EditChannelTagGroups (string payload) { }
         public void EditChannelAttributes (string payload) { }
+        public bool DataCollectionEnabled { get; set; }
+        public bool PushTokenRegistrationEnabled { get; set; }
     }
 }

--- a/Assets/UrbanAirship/Platforms/UAirship.cs
+++ b/Assets/UrbanAirship/Platforms/UAirship.cs
@@ -406,6 +406,32 @@ namespace UrbanAirship {
             });
         }
 
+        /// <summary>
+        /// Determines whether the data collection is enabled.
+        /// </summary>
+        /// <value><c>true</c> if data collection is enabled; otherwise, <c>false</c>.</value>
+        public bool DataCollectionEnabled {
+             get {
+                return plugin.DataCollectionEnabled;
+             }
+             set {
+                plugin.DataCollectionEnabled = value;
+             }
+        }
+
+        /// <summary>
+        /// Determines whether push token registration is enabled.
+        // </summary>
+        /// <value><c>true</c> if push token registration enabled; otherwise, <c>false</c>.</value>
+        public bool PushTokenRegistrationEnabled {
+            get {
+                return plugin.PushTokenRegistrationEnabled;
+            }
+            set {
+                plugin.PushTokenRegistrationEnabled = value;
+            }
+        }
+
         internal class UrbanAirshipListener : MonoBehaviour {
             void OnPushReceived (string payload) {
                 PushReceivedEventHandler handler = UAirship.Shared.OnPushReceived;

--- a/Assets/UrbanAirship/Platforms/iOS/UAirshipPluginIOS.cs
+++ b/Assets/UrbanAirship/Platforms/iOS/UAirshipPluginIOS.cs
@@ -114,6 +114,17 @@ namespace UrbanAirship {
 
         [DllImport ("__Internal")]
         private static extern void UAUnityPlugin_setInAppAutomationPaused (bool paused);
+        [DllImport ("__Internal")]
+        private static extern bool UAUnityPlugin_isDataCollectionEnabled ();
+
+        [DllImport ("__Internal")]
+        private static extern void UAUnityPlugin_setDataCollectionEnabled (bool enabled);
+
+        [DllImport ("__Internal")]
+        private static extern bool UAUnityPlugin_isPushTokenRegistrationEnabled ();
+
+        [DllImport ("__Internal")]
+        private static extern void UAUnityPlugin_setPushTokenRegistrationEnabled (bool enabled);
 
         public bool UserNotificationsEnabled {
             get {
@@ -266,6 +277,24 @@ namespace UrbanAirship {
 
         public void EditChannelAttributes (string payload) {
             UAUnityPlugin_editChannelAttributes (payload);
+        }
+
+        public bool DataCollectionEnabled {
+            get {
+                return UAUnityPlugin_isDataCollectionEnabled();
+            }
+            set {
+                UAUnityPlugin_setDataCollectionEnabled(value);
+            }
+        }
+
+        public bool PushTokenRegistrationEnabled {
+            get {
+                return UAUnityPlugin_isPushTokenRegistrationEnabled();
+            }
+            set {
+                UAUnityPlugin_setPushTokenRegistrationEnabled(value);
+            }
         }
     }
 }

--- a/unity-plugin/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
+++ b/unity-plugin/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
@@ -658,8 +658,17 @@ public class UnityPlugin {
         UAirship.shared().setDataCollectionEnabled(enabled);
     }
 
+    public boolean isDataCollectionEnabled() {
+        PluginLogger.debug("UnityPlugin isDataCollectionEnabled");
+        return UAirship.shared().isDataCollectionEnabled();
+    }
+
     public void setPushTokenRegistrationEnabled(boolean enabled) {
         PluginLogger.debug("UnityPlugin setPushTokenRegistrationEnabled: " + enabled);
         UAirship.shared().getPushManager().setPushTokenRegistrationEnabled(enabled);
+    }
+    public public boolean isPushTokenRegistrationEnabled() {
+        PluginLogger.debug("UnityPlugin isPushTokenRegistrationEnabled");
+        return UAirship.shared().getPushManager().isPushTokenRegistrationEnabled();
     }
 }

--- a/unity-plugin/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
+++ b/unity-plugin/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
@@ -652,4 +652,14 @@ public class UnityPlugin {
             }
         }
     }
+
+    public void setDataCollectionEnabled(boolean enabled) {
+        PluginLogger.debug("UnityPlugin setDataCollectionEnabled: " + enabled);
+        UAirship.shared().setDataCollectionEnabled(enabled);
+    }
+
+    public void setPushTokenRegistrationEnabled(boolean enabled) {
+        PluginLogger.debug("UnityPlugin setPushTokenRegistrationEnabled: " + enabled);
+        UAirship.shared().getPushManager().setPushTokenRegistrationEnabled(enabled);
+    }
 }

--- a/unity-plugin/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
+++ b/unity-plugin/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
@@ -667,7 +667,8 @@ public class UnityPlugin {
         PluginLogger.debug("UnityPlugin setPushTokenRegistrationEnabled: " + enabled);
         UAirship.shared().getPushManager().setPushTokenRegistrationEnabled(enabled);
     }
-    public public boolean isPushTokenRegistrationEnabled() {
+
+    public boolean isPushTokenRegistrationEnabled() {
         PluginLogger.debug("UnityPlugin isPushTokenRegistrationEnabled");
         return UAirship.shared().getPushManager().isPushTokenRegistrationEnabled();
     }


### PR DESCRIPTION
### What do these changes do?
Add data collection enabled flag to Unity

<img width="1050" alt="Screen Shot 2020-03-10 at 2 57 26 PM" src="https://user-images.githubusercontent.com/3967591/76363085-8d88c000-62df-11ea-9610-8051477956ec.png">

### Why are these changes necessary?
to support data collection feature

### Testing
I manually tested both iOS and Android


