### PR TITLE
[MOBILE-1569] Add date attributes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # https://help.github.com/en/articles/about-code-owners
-*       @BrianBatchelder @marc-scig @crow @rlepinski
+*       @BrianBatchelder @marc-scig @crow @rlepinski @khmMouna @oristanovic @Apekka @Ulrico972

--- a/Assets/Plugins/iOS/UAUnityPlugin.m
+++ b/Assets/Plugins/iOS/UAUnityPlugin.m
@@ -695,7 +695,7 @@ bool UAUnityPlugin_isPushTokenRegistrationEnabled() {
             } else if ([type isEqualToString:@"String"]) {
                 [mutations setString:value forAttribute:key];
             } else if ([type isEqualToString:@"Date"]) {
-                NSDate *date = [NSDate dateWithTimeIntervalSince1970:[value doubleValue]];
+                NSDate *date = [NSDate dateWithTimeIntervalSince1970:(NSTimeInterval)([value doubleValue] / 1000.0)];
                 [mutations setDate:date forAttribute:key];
             }
         } else if ([action isEqualToString:@"Remove"]) {

--- a/Assets/Plugins/iOS/UAUnityPlugin.m
+++ b/Assets/Plugins/iOS/UAUnityPlugin.m
@@ -695,7 +695,7 @@ bool UAUnityPlugin_isPushTokenRegistrationEnabled() {
             } else if ([type isEqualToString:@"String"]) {
                 [mutations setString:value forAttribute:key];
             } else if ([type isEqualToString:@"Date"]) {
-                NSDate *date = [NSDate dateWithTimeIntervalSince1970:(NSTimeInterval)([value doubleValue] / 1000.0)];
+                NSDate *date = [NSDate dateWithTimeIntervalSince1970:(NSTimeInterval)(value.doubleValue / 1000.0)];
                 [mutations setDate:date forAttribute:key];
             }
         } else if ([action isEqualToString:@"Remove"]) {

--- a/Assets/Plugins/iOS/UAUnityPlugin.m
+++ b/Assets/Plugins/iOS/UAUnityPlugin.m
@@ -694,6 +694,9 @@ bool UAUnityPlugin_isPushTokenRegistrationEnabled() {
                 [mutations setNumber:@(value.intValue) forAttribute:key];
             } else if ([type isEqualToString:@"String"]) {
                 [mutations setString:value forAttribute:key];
+            } else if ([type isEqualToString:@"Date"]) {
+                NSDate *date = [NSDate dateWithTimeIntervalSince1970:[value doubleValue]];
+                [mutations setDate:date forAttribute:key];
             }
         } else if ([action isEqualToString:@"Remove"]) {
             [mutations removeAttribute:key];

--- a/Assets/Scripts/UrbanAirshipBehaviour.cs
+++ b/Assets/Scripts/UrbanAirshipBehaviour.cs
@@ -1,5 +1,6 @@
 /* Copyright Airship and Contributors */
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -29,6 +30,13 @@ public class UrbanAirshipBehaviour : MonoBehaviour {
         UAirship.Shared.TrackScreen("Main Camera");
 
         UAirship.Shared.RefreshInbox();
+
+        UAirship.Shared.EditChannelAttributes().SetAttribute("teststring", "a_string").Apply();
+        UAirship.Shared.EditChannelAttributes().SetAttribute("testint", (int) 1).Apply();
+        UAirship.Shared.EditChannelAttributes().SetAttribute("testlong", (long) 1000).Apply();
+        UAirship.Shared.EditChannelAttributes().SetAttribute("testfloat", (float)5.99).Apply();
+        UAirship.Shared.EditChannelAttributes().SetAttribute("testdouble", (double)5555.999).Apply();
+        UAirship.Shared.EditChannelAttributes().SetAttribute("testdate", DateTime.UtcNow).Apply();
     }
 
     void OnDestroy () {

--- a/Assets/UrbanAirship/Platforms/AttributeEditor.cs
+++ b/Assets/UrbanAirship/Platforms/AttributeEditor.cs
@@ -109,9 +109,9 @@ namespace UrbanAirship {
 
             // Pass date to the plugin as seconds since the epoch
             System.DateTime epochStart = new System.DateTime(1970, 1, 1, 0, 0, 0, System.DateTimeKind.Utc);
-            int valueInSecondsSinceEpoch = (int)(value - epochStart).TotalSeconds;
+            double valueInMillisecondsSinceEpoch = (value - epochStart).TotalMilliseconds;
 
-            operations.Add(new AttributeMutation(AttributeAction.Set, key, valueInSecondsSinceEpoch, AttributeType.Date));
+            operations.Add(new AttributeMutation(AttributeAction.Set, key, valueInMillisecondsSinceEpoch, AttributeType.Date));
             return this;
         }
 

--- a/Assets/UrbanAirship/Platforms/AttributeEditor.cs
+++ b/Assets/UrbanAirship/Platforms/AttributeEditor.cs
@@ -95,6 +95,27 @@ namespace UrbanAirship {
         }
 
         /// <summary>
+        /// Sets a date attribute.
+        /// </summary>
+        /// <returns>The AttributeEditor</returns>
+        /// <param name="key">The attribute key greater than one character and less than 1024 characters in length.</param>
+        /// <param name="value">The date attribute value.</param>
+        public AttributeEditor SetAttribute(string key, DateTime value)
+        {
+            if (IsInvalidField(key))
+            {
+                return this;
+            }
+
+            // Pass date to the plugin as seconds since the epoch
+            System.DateTime epochStart = new System.DateTime(1970, 1, 1, 0, 0, 0, System.DateTimeKind.Utc);
+            int valueInSecondsSinceEpoch = (int)(value - epochStart).TotalSeconds;
+
+            operations.Add(new AttributeMutation(AttributeAction.Set, key, valueInSecondsSinceEpoch, AttributeType.Date));
+            return this;
+        }
+
+        /// <summary>
         /// Removes an attribute.
         /// </summary>
         /// <returns>The AttributeEditor</returns>
@@ -136,7 +157,8 @@ namespace UrbanAirship {
             Long,
             Float,
             Double,
-            String
+            String,
+            Date
         }
 
         internal enum AttributeAction {

--- a/unity-plugin/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
+++ b/unity-plugin/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
@@ -29,6 +29,7 @@ import com.urbanairship.util.UAStringUtil;
 import org.json.JSONArray;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -648,6 +649,9 @@ public class UnityPlugin {
                             break;
                         case "Double":
                             editor.setAttribute(key, Double.valueOf(value));
+                            break;
+                        case "Date":
+                            editor.setAttribute(key, new Date(Long.valueOf(value) * 1000));
                             break;
                         default:
                             PluginLogger.error("Unexpected type: " + operation);

--- a/unity-plugin/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
+++ b/unity-plugin/src/main/java/com/urbanairship/unityplugin/UnityPlugin.java
@@ -651,7 +651,7 @@ public class UnityPlugin {
                             editor.setAttribute(key, Double.valueOf(value));
                             break;
                         case "Date":
-                            editor.setAttribute(key, new Date(Long.valueOf(value) * 1000));
+                            editor.setAttribute(key, new Date(Double.valueOf(value).longValue()));
                             break;
                         default:
                             PluginLogger.error("Unexpected type: " + operation);


### PR DESCRIPTION
### What do these changes do?
Add date attribute support to our Unity plugin.

### Why are these changes necessary?
We want to provide full attribute support to our Unity customers.

### How did you verify these changes?
Built new sample apps and tested that date (and other) attributes were set correctly.

#### Verification Screenshots:
<img width="884" alt="Screen Shot 2020-06-16 at 11 47 52 AM" src="https://user-images.githubusercontent.com/2123928/84817594-15125900-afca-11ea-844a-70783c3129af.png">
<img width="884" alt="Screen Shot 2020-06-16 at 12 00 35 PM" src="https://user-images.githubusercontent.com/2123928/84817588-12afff00-afca-11ea-9c7a-1dc77bb7ad00.png">
