### PR TITLE
MOBILE-1930 Unity plugin 8.0.1

### DIFF
--- a/Assets/Plugins/iOS/UAUnityPlugin.m
+++ b/Assets/Plugins/iOS/UAUnityPlugin.m
@@ -62,7 +62,7 @@ NSString *const UAUnityPluginVersionKey = @"UAUnityPluginVersion";
                                                object:nil];
 
     [[NSNotificationCenter defaultCenter] addObserver:[self shared]
-                                             selector:@selector(channelRegistrationSucceeded:)
+                                             selector:@selector(channelUpdated:)
                                                  name:UAChannelUpdatedEvent
                                                object:nil];
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unity Plugin ChangeLog
 
+## Version 8.0.1 - October 1, 2020
+
+Patch release fixing a crash related to channel update events in the iOS plugin. Apps currently
+on version 8.0.0 should update, and when upgrading previous plugin versions to 8.x, 8.0.0 should
+be avoided.  
+
 ## Version 8.0.0 - September 25, 2020
 
 Major release that updates Airship Android SDK to 14.0.1 and iOS SDK to 14.1.2. Starting with SDK 14, all landing page and external urls are tested against a URL allow list. The easiest way to go back to previous behavior is to add the wildcard symbol * in the Scope Open in URL Allow List in the Airship Config window.

--- a/airship.properties
+++ b/airship.properties
@@ -1,5 +1,5 @@
 # Plugin version
-version = 8.0.0
+version = 8.0.1
 
 # Urban Airship iOS SDK version
 iosAirshipVersion = 14.1.2


### PR DESCRIPTION
The iOS plugin is using the wrong selector for the channel updated event, which leads to an unrecognized selector crash. See: https://github.com/urbanairship/ua-unity-plugin/issues/122

This warrants a patch, since it will crash any iOS Unity app that does any CRA work beyond channel creation.

~Note: I haven't tested this yet since my Unity environment is extremely out of date. If anyone wants to help verify I'd appreciate it.~

Building and running fine locally for me now, and independently verified by ryan