### PR TITLE
[MOBILE-2438] Update setup-cloud action in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,9 +76,9 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
       - name: Setup GCP
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@daadedc81d5f9d3c06d2c92f49202a3cc2b919ba # v0.2.1
         with:
-          version: "270.0.0"
+          version: '351.0.0'
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
 


### PR DESCRIPTION
### What do these changes do?

Updates to the new modular GCP setup action.

### Why are these changes necessary?

So that deploys continue working.

### How did you verify these changes?

Doing it live, but tested the new action in a private repo and it installed the GCP CLI utils without issue.