### PR TITLE
[MOBILE-2960] Fix crash and prepare release 9.0.2

### DIFF
--- a/Assets/Plugins/iOS/UAUnityPlugin.m
+++ b/Assets/Plugins/iOS/UAUnityPlugin.m
@@ -440,7 +440,7 @@ void UAUnityPlugin_editNamedUserAttributes(const char *payload) {
 - (void)channelUpdated:(NSNotification *)notification {
     NSString *channelID = notification.userInfo[UAChannel.channelUpdatedEvent];
     UA_LDEBUG(@"channelUpdated: %@", channelID);
-    if (self.listener) {
+    if (self.listener && !channelID) {
         UnitySendMessage(MakeStringCopy([self.listener UTF8String]),
                          "OnChannelUpdated",
                          MakeStringCopy([channelID UTF8String]));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unity Plugin ChangeLog
 
+## Version 9.0.2 - March 15, 2022
+
+Patch release that fixes an iOS crash related to push registration.
+
+### Changes
+- Fix iOS crash during registration
+
 ## Version 9.0.1 - March 1, 2022
 
 Patch release that fixes an iOS error related to a wrong method name.

--- a/airship.properties
+++ b/airship.properties
@@ -1,5 +1,5 @@
 # Plugin version
-version = 9.0.1
+version = 9.0.2
 
 # Urban Airship iOS SDK version
 iosAirshipVersion = 16.1.1


### PR DESCRIPTION
Following MOBILE-2960, a crash happens when you register and the channel ID is null

### What do these changes do?
Add a check to avoid Unity crash

### Why are these changes necessary?
To avoid crash

### How did you verify these changes?
Run the app, check that no crash occurs at first, second, and other launches, when you register or not to pushes