### PR TITLE
[MOBILE-2960] Patch 9.0.3

### DIFF
--- a/Assets/Plugins/iOS/UAUnityPlugin.m
+++ b/Assets/Plugins/iOS/UAUnityPlugin.m
@@ -440,7 +440,7 @@ void UAUnityPlugin_editNamedUserAttributes(const char *payload) {
 - (void)channelUpdated:(NSNotification *)notification {
     NSString *channelID = notification.userInfo[UAChannel.channelUpdatedEvent];
     UA_LDEBUG(@"channelUpdated: %@", channelID);
-    if (self.listener && !channelID) {
+    if (self.listener && channelID) {
         UnitySendMessage(MakeStringCopy([self.listener UTF8String]),
                          "OnChannelUpdated",
                          MakeStringCopy([channelID UTF8String]));

--- a/Assets/Plugins/iOS/UAUnityPlugin.m
+++ b/Assets/Plugins/iOS/UAUnityPlugin.m
@@ -438,7 +438,7 @@ void UAUnityPlugin_editNamedUserAttributes(const char *payload) {
 
 
 - (void)channelUpdated:(NSNotification *)notification {
-    NSString *channelID = notification.userInfo[UAChannel.channelUpdatedEvent];
+    NSString *channelID = notification.userInfo[UAChannel.channelIdentifierKey];
     UA_LDEBUG(@"channelUpdated: %@", channelID);
     if (self.listener && channelID) {
         UnitySendMessage(MakeStringCopy([self.listener UTF8String]),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unity Plugin ChangeLog
 
-## Version 9.0.3 - April 1, 2022
+## Version 9.0.3 - April 6, 2022
 
 Patch release that fixes an other iOS crash related to channel update event.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unity Plugin ChangeLog
 
+## Version 9.0.3 - April 1, 2022
+
+Patch release that fixes an other iOS crash related to channel update event.
+
+### Changes
+- Fix iOS crash when channel is updated
+
 ## Version 9.0.2 - March 15, 2022
 
 Patch release that fixes an iOS crash related to push registration.

--- a/airship.properties
+++ b/airship.properties
@@ -1,5 +1,5 @@
 # Plugin version
-version = 9.0.2
+version = 9.0.3
 
 # Urban Airship iOS SDK version
 iosAirshipVersion = 16.1.1


### PR DESCRIPTION
### What do these changes do?
Fix a crash when the channel ID is null

### Why are these changes necessary?
To fix a crash when channelID is null, requested by a customer : https://urbanairship.atlassian.net/jira/software/c/projects/MOBILE/boards/12?modal=detail&selectedIssue=MOBILE-2960

### How did you verify these changes?
Uninstall the app, installed it and check that after first launch, registering to push, it doesn't crash