### PR TITLE
[MOBILE-3077] Update Unity Plugin 9.1.0

### DIFF
--- a/Assets/Plugins/iOS/UAUnityPlugin.h
+++ b/Assets/Plugins/iOS/UAUnityPlugin.h
@@ -2,15 +2,7 @@
 
 #import <Foundation/Foundation.h>
 #if __has_include("UAirship.h")
-#import "UAirship.h"
-#import "UAMessageCenter.h"
-#import "UAPush.h"
-#import "UAInboxMessage.h"
-#import "UAAnalytics.h"
-#import "UAInboxMessageList.h"
-#import "UAInAppAutomation.h"
-#import "UADefaultMessageCenterUI.h"
-#import "UAAssociatedIdentifiers.h"
+#import "AirshipLib.h"
 #else
 @import AirshipKit;
 #endif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Unity Plugin ChangeLog
 
+## Version 9.1.0 - May 11, 2022
+
+Minor release that updates to the latest SDK versions.
+
+### Changes
+- Updated Android Airship SDK to 16.4.0
+- Updated iOS Airship SDK to 16.6.0
+
 ## Version 9.0.3 - April 6, 2022
 
 Patch release that fixes an other iOS crash related to channel update event.

--- a/airship.properties
+++ b/airship.properties
@@ -1,11 +1,11 @@
 # Plugin version
-version = 9.0.3
+version = 9.1.0
 
 # Urban Airship iOS SDK version
-iosAirshipVersion = 16.1.1
+iosAirshipVersion = 16.6.0
 
 # Urban Airship Android SDK version
-androidAirshipVersion = 16.1.0
+androidAirshipVersion = 16.4.0
 
 # Android X annotations
 androidxAnnotationVersion = 1.1.0


### PR DESCRIPTION
### What do these changes do?
Update Unity plugin version to 9.1.0, Android SDK to 16.4.0 and iOS version to 16.6.0

### Why are these changes necessary?
To keep the plugins updated

### How did you verify these changes?
By running a sample app embedding the new plugin