### PR TITLE
[MOBILE-4122] Release 9.2.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       # Build
       - name: Build project
         env:
-          UNITY_USERNAME: ${{ secrets.UNITY_USERNAME }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_USERNAME: ${{ secrets.ULRICH_UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.ULRICH_UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.ULRICH_UNITY_SERIAL }}
         run: ./scripts/docker_run.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,9 +33,9 @@ jobs:
 
       - name: Build
         env:
-          UNITY_USERNAME: ${{ secrets.UNITY_USERNAME }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_USERNAME: ${{ secrets.ULRICH_UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.ULRICH_UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.ULRICH_UNITY_SERIAL }}
         run: ./scripts/docker_run.sh
 
       - name: Create Github Release
@@ -60,10 +60,10 @@ jobs:
           asset_name: urbanairship-${{ steps.get_version.outputs.VERSION }}.unitypackage
           asset_content_type: application/octet-stream
 
-      - name: Bintray Release
-        env:
-          BINTRAY_AUTH: ${{ secrets.BINTRAY_AUTH }}
-        run: bash ./scripts/deploy_bintray.sh ${{ steps.get_version.outputs.VERSION }}
+#      - name: Bintray Release
+#        env:
+#          BINTRAY_AUTH: ${{ secrets.BINTRAY_AUTH }}
+#        run: bash ./scripts/deploy_bintray.sh ${{ steps.get_version.outputs.VERSION }}
 
   docs:
     runs-on: ubuntu-latest

--- a/Assets/UrbanAirship/Platforms/AttributeEditor.cs
+++ b/Assets/UrbanAirship/Platforms/AttributeEditor.cs
@@ -1,6 +1,7 @@
 /* Copyright Airship and Contributors */
 
 using System;
+using System.Globalization;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -42,7 +43,7 @@ namespace UrbanAirship {
             if (IsInvalidField (key)) {
                 return this;
             }
-            operations.Add (new AttributeMutation (AttributeAction.Set, key, value, AttributeType.Integer));
+            operations.Add (new AttributeMutation (AttributeAction.Set, key, value.ToString(CultureInfo.InvariantCulture), AttributeType.Integer));
             return this;
         }
 
@@ -56,7 +57,7 @@ namespace UrbanAirship {
             if (IsInvalidField (key)) {
                 return this;
             }
-            operations.Add (new AttributeMutation (AttributeAction.Set, key, value, AttributeType.Long));
+            operations.Add (new AttributeMutation (AttributeAction.Set, key, value.ToString(CultureInfo.InvariantCulture), AttributeType.Long));
             return this;
         }
 
@@ -73,7 +74,7 @@ namespace UrbanAirship {
             if (float.IsNaN (value) || float.IsInfinity (value)) {
                 throw new FormatException ("Infinity or NaN: " + value);
             }
-            operations.Add (new AttributeMutation (AttributeAction.Set, key, value, AttributeType.Float));
+            operations.Add (new AttributeMutation (AttributeAction.Set, key, value.ToString(CultureInfo.InvariantCulture), AttributeType.Float));
             return this;
         }
 
@@ -90,7 +91,7 @@ namespace UrbanAirship {
             if (double.IsNaN (value) || double.IsInfinity (value)) {
                 throw new FormatException ("Infinity or NaN: " + value);
             }
-            operations.Add (new AttributeMutation (AttributeAction.Set, key, value, AttributeType.Double));
+            operations.Add (new AttributeMutation (AttributeAction.Set, key, value.ToString(CultureInfo.InvariantCulture), AttributeType.Double));
             return this;
         }
 
@@ -109,7 +110,7 @@ namespace UrbanAirship {
 
             // Pass date to the plugin as seconds since the epoch
             System.DateTime epochStart = new System.DateTime(1970, 1, 1, 0, 0, 0, System.DateTimeKind.Utc);
-            double valueInMillisecondsSinceEpoch = (value - epochStart).TotalMilliseconds;
+            string valueInMillisecondsSinceEpoch = (value - epochStart).TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
 
             operations.Add(new AttributeMutation(AttributeAction.Set, key, valueInMillisecondsSinceEpoch, AttributeType.Date));
             return this;
@@ -185,11 +186,11 @@ namespace UrbanAirship {
             private string type;
 #pragma warning restore
 
-            public AttributeMutation (AttributeAction action, string key, object value, AttributeType type) {
-                this.action = action.ToString ();
+            public AttributeMutation (AttributeAction action, string key, string value, AttributeType type) {
+                this.action = action.ToString();
                 this.key = key;
-                this.value = value == null ? null : value.ToString ();
-                this.type = type.ToString ();
+                this.value = value;
+                this.type = type.ToString();
             }
         }
     }

--- a/Assets/UrbanAirship/Platforms/CustomEvent.cs
+++ b/Assets/UrbanAirship/Platforms/CustomEvent.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using UnityEngine;
 
@@ -51,8 +52,8 @@ namespace UrbanAirship {
         /// </summary>
         /// <value>The event value.</value>
         public decimal EventValue {
-            get { return Decimal.Parse (eventValue); }
-            set { eventValue = value.ToString (); }
+            get { return Decimal.Parse(eventValue, CultureInfo.InvariantCulture); }
+            set { eventValue = value.ToString(CultureInfo.InvariantCulture); }
         }
 
         /// <summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unity Plugin ChangeLog
 
+## Version 9.2.1 - February 5, 2024
+
+Patch release that fixes an issue with decimal attribute values on certain locales. Apps that make use of attributes with decimal values should update.
+
+### Changes
+- Fixed decimal attribute values for locales that use a comma as the decimal separator.
+
 ## Version 9.2.0 - September 15, 2022
 
 Minor release that updates to the latest SDK versions.

--- a/airship.properties
+++ b/airship.properties
@@ -1,5 +1,5 @@
 # Plugin version
-version = 9.2.0
+version = 9.2.1
 
 # Urban Airship iOS SDK version
 iosAirshipVersion = 16.9.3


### PR DESCRIPTION
### What do these changes do?

- Changed several usages of `ToString()` to `ToString(CultureInfo.InvariantCulture)` to avoid the possibility of formatting with a comma as the decimal separator.
- Bumped to version 9.2.1
- Updated changelog

### Why are these changes necessary?

Customer reported issue

### How did you verify these changes?

Imported the package into an empty sample app, set up credentials, and added the sample behavior to a game object, then ran on device with the language set to French. I was able to reproduce the issue and confirm that it no longer happens with this fix.
