### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
+
 # https://help.github.com/en/articles/about-code-owners
-*       @BrianBatchelder @marc-scig @crow @rlepinski @khmMouna @oristanovic @Apekka @Ulrico972
+*       @urbanairship/mobile


### PR DESCRIPTION
Updates CODEOWNERS to @urbanairship/mobile, like we're already doing this in the flutter, capacitor, and cordova repos.