### PR TITLE
Extract doc publishing into reusable workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,77 @@
+name: Publish Docs
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+    secrets:
+      GCP_SA_KEY:
+        required: true
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to publish docs for (e.g. 12.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  release-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Setup GCP Auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Build & Package docs
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          sudo apt-get install -y doxygen
+          ./gradlew docs:build
+
+      - name: Upload docs
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          gsutil cp docs/build/$VERSION.tar.gz gs://ua-web-ci-prod-docs-transfer/libraries/unity/$VERSION.tar.gz
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/build/html
+
+  deploy-docs:
+    needs: release-docs
+    runs-on: ubuntu-latest
+    continue-on-error: true # Remove when migration to GH Pages is complete
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,27 +16,31 @@ jobs:
           - Android # Build an Android .apk standalone app.
           
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Get Version
+      - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: |
+          echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Verify Version
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
-          VERSION=${{ steps.get_version.outputs.VERSION }}
           PLUGIN_VERSION=$(./gradlew -q getPluginVersion)
           if [[ $PLUGIN_VERSION = $VERSION ]]; then exit 0 ; else exit 1; fi
 
-      - name: Get Release Notes
+      - name: Get the release notes
         id: get_release_notes
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
-          VERSION=${{ steps.get_version.outputs.VERSION }}
-          NOTES="$(awk "/## Version $VERSION/{flag=1;next}/## Version/{flag=0}flag" CHANGELOG.md)"
-          NOTES="${NOTES//'%'/'%25'}"
-          NOTES="${NOTES//$'\n'/'%0A'}"
-          NOTES="${NOTES//$'\r'/'%0D'}"
-          echo ::set-output name=NOTES::"$NOTES"
+          delimiter="$(openssl rand -hex 8)"
+          {
+            echo "NOTES<<${delimiter}"
+            awk "/## Version $VERSION/{flag=1;next}/## Version/{flag=0}flag" CHANGELOG.md
+            echo ${delimiter}
+          } >> $GITHUB_OUTPUT
 
       - name: Build
         uses: game-ci/unity-builder@v4
@@ -69,39 +73,13 @@ jobs:
           asset_name: urbanairship-${{ steps.get_version.outputs.VERSION }}.unitypackage
           asset_content_type: application/octet-stream
 
-#      - name: Bintray Release
-#        env:
-#          BINTRAY_AUTH: ${{ secrets.BINTRAY_AUTH }}
-#        run: bash ./scripts/deploy_bintray.sh ${{ steps.get_version.outputs.VERSION }}
-
-  docs:
-    runs-on: ubuntu-latest
+  publish-docs:
     needs: plugin
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Get Version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
-      - name: Setup GCP
-        uses: google-github-actions/setup-gcloud@daadedc81d5f9d3c06d2c92f49202a3cc2b919ba # v0.2.1
-        with:
-          version: '351.0.0'
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
-      - name: Build Docs
-        run: |
-          sudo apt-get install doxygen
-          ./gradlew docs:build
-
-      - name: Upload Docs
-        run: |
-          VERSION=${{ steps.get_version.outputs.VERSION }}
-          gsutil cp docs/build/$VERSION.tar.gz gs://ua-web-ci-prod-docs-transfer/libraries/unity/$VERSION.tar.gz
+    uses: ./.github/workflows/publish-docs.yml
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    with:
+      version: ${{ github.ref_name }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish-docs.yml`: a reusable workflow triggered by `workflow_call` (automatic on tag push) and `workflow_dispatch` (manual republish from the GitHub UI). Checks out the specified version tag, builds docs with doxygen + Gradle, uploads the tarball to GCS (`libraries/unity/<version>.tar.gz`), and deploys HTML to GitHub Pages.
- Replaces the inline `docs` job in `release.yaml` with a `publish-docs` caller job that passes `version: ${{ github.ref_name }}` and `secrets: inherit`.
- Modernizes the `plugin` job in `release.yaml`: `checkout@v4`, `$GITHUB_OUTPUT` (replaces deprecated `set-output`), `env:` blocks for version variable, secure random-delimiter multiline output for release notes.

## Notes

- `GCP_SA_KEY` must be a full JSON service account key blob — the new `google-github-actions/auth@v2` step expects `credentials_json`, replacing the legacy `setup-gcloud@v0.2.1` format. Verify the secret before the first tag push.
- The `workflow_dispatch` path runs `deploy-docs` (GitHub Pages) with job-level `pages: write` + `id-token: write`; a top-level `permissions` block in `publish-docs.yml` ensures those are available for manual runs.

## Test plan

- [ ] Verify a tag push triggers the release workflow and `publish-docs` runs after both `plugin` matrix jobs succeed
- [ ] Verify docs appear at the expected GCS path and GitHub Pages URL
- [ ] Trigger `publish-docs` manually via workflow_dispatch for an existing tag and confirm it republishes correctly
- [ ] Confirm `GCP_SA_KEY` secret is in JSON format before first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)